### PR TITLE
feat: add Windows x64 installer and binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,14 @@ jobs:
             target: linux-arm64
             node_arch: arm64
             node_platform: linux
+          - os: windows-latest
+            target: windows-x64
+            node_arch: x64
+            node_platform: win
+          # NOTE: Windows arm64 is not yet supported — GitHub Actions does not
+          # provide Windows arm64 runners. Node.js ships win-arm64 binaries, so
+          # when runners become available, add a windows-arm64 entry here.
+          # The install.ps1 script already detects ARM64 and prints an error.
 
     runs-on: ${{ matrix.os }}
 
@@ -36,6 +44,7 @@ jobs:
 
       - name: Read Node.js version
         id: node-version
+        shell: bash
         run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v4
@@ -48,10 +57,20 @@ jobs:
       - name: Build standalone
         run: npm run build
 
-      - name: Assemble standalone
+      # --- Unix assembly ---
+      - name: Assemble standalone (Unix)
+        if: runner.os != 'Windows'
         run: bash scripts/assemble-standalone.sh
 
-      - name: Download Node.js binary
+      # --- Windows assembly ---
+      - name: Assemble standalone (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh scripts/assemble-standalone.ps1
+
+      # --- Unix: Download Node.js binary ---
+      - name: Download Node.js binary (Unix)
+        if: runner.os != 'Windows'
         run: |
           NODE_VERSION="${{ steps.node-version.outputs.version }}"
           PLATFORM="${{ matrix.node_platform }}"
@@ -64,7 +83,25 @@ jobs:
           cp "${NODE_DIST}/bin/node" staging/bin/node
           chmod +x staging/bin/node
 
-      - name: Package tarball
+      # --- Windows: Download Node.js binary ---
+      - name: Download Node.js binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $NodeVersion = "${{ steps.node-version.outputs.version }}"
+          $Arch = "${{ matrix.node_arch }}"
+          $NodeDist = "node-v${NodeVersion}-win-${Arch}"
+          $ZipUrl = "https://nodejs.org/dist/v${NodeVersion}/${NodeDist}.zip"
+
+          Invoke-WebRequest -Uri $ZipUrl -OutFile node-dist.zip -UseBasicParsing
+          Expand-Archive -Path node-dist.zip -DestinationPath . -Force
+
+          New-Item -ItemType Directory -Path staging/bin -Force | Out-Null
+          Copy-Item "${NodeDist}/node.exe" staging/bin/node.exe
+
+      # --- Unix: Package tarball ---
+      - name: Package tarball (Unix)
+        if: runner.os != 'Windows'
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           TARGET="${{ matrix.target }}"
@@ -107,13 +144,73 @@ jobs:
             shasum -a 256 "${DIR_NAME}.tar.gz" > "${DIR_NAME}.tar.gz.sha256"
           fi
 
-      - name: Upload artifact
+      # --- Windows: Package zip ---
+      - name: Package zip (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $Version = "$env:GITHUB_REF_NAME" -replace '^v', ''
+          $Target = "${{ matrix.target }}"
+          $DirName = "weave-fleet-v${Version}-${Target}"
+
+          New-Item -ItemType Directory -Path "${DirName}/bin" -Force | Out-Null
+          New-Item -ItemType Directory -Path "${DirName}/app" -Force | Out-Null
+
+          # Copy Node.js binary
+          Copy-Item staging/bin/node.exe "${DirName}/bin/node.exe"
+
+          # Copy launcher script
+          Copy-Item scripts/launcher.cmd "${DirName}/bin/weave-fleet.cmd"
+
+          # Determine standalone directory (may be nested under project name)
+          $StandaloneSrc = $null
+          if (Test-Path ".next/standalone/server.js") {
+            $StandaloneSrc = ".next/standalone"
+          } else {
+            $nested = Get-ChildItem -Path ".next/standalone" -Directory | Where-Object {
+              Test-Path (Join-Path $_.FullName "server.js")
+            } | Select-Object -First 1
+            if ($nested) {
+              $StandaloneSrc = $nested.FullName
+            }
+          }
+
+          if (-not $StandaloneSrc) {
+            Write-Error "standalone server.js not found"
+            exit 1
+          }
+
+          # Copy standalone app
+          Copy-Item -Path "${StandaloneSrc}/*" -Destination "${DirName}/app/" -Recurse -Force
+
+          # Write version
+          Set-Content -Path "${DirName}/VERSION" -Value $Version -NoNewline
+
+          # Create zip
+          Compress-Archive -Path $DirName -DestinationPath "${DirName}.zip" -Force
+
+          # Generate checksum
+          $hash = (Get-FileHash -Path "${DirName}.zip" -Algorithm SHA256).Hash.ToLower()
+          Set-Content -Path "${DirName}.zip.sha256" -Value "${hash}  ${DirName}.zip"
+
+      # --- Upload artifacts ---
+      - name: Upload artifact (Unix)
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: tarball-${{ matrix.target }}
           path: |
             weave-fleet-*.tar.gz
             weave-fleet-*.tar.gz.sha256
+
+      - name: Upload artifact (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarball-${{ matrix.target }}
+          path: |
+            weave-fleet-*.zip
+            weave-fleet-*.zip.sha256
 
   release:
     needs: build
@@ -136,5 +233,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/weave-fleet-*.tar.gz
+            artifacts/weave-fleet-*.zip
             artifacts/checksums.txt
             scripts/install.sh
+            scripts/install.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 staging/
 weave-fleet-*.tar.gz
 weave-fleet-*.tar.gz.sha256
+weave-fleet-*.zip
+weave-fleet-*.zip.sha256

--- a/README.md
+++ b/README.md
@@ -10,8 +10,16 @@ A fleet orchestrator for managing multiple OpenCode AI agent sessions from a sin
 
 ### Install
 
+**macOS / Linux:**
+
 ```sh
 curl -fsSL https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 | iex
 ```
 
 ### Run
@@ -40,8 +48,8 @@ weave-fleet uninstall
 |---------------------|---------|-------------|
 | `PORT` | `3000` | Server port |
 | `HOSTNAME` | `0.0.0.0` | Server hostname |
-| `WEAVE_DB_PATH` | `~/.weave/fleet.db` | SQLite database path |
-| `WEAVE_INSTALL_DIR` | `~/.weave/fleet` | Installation directory (used by installer) |
+| `WEAVE_DB_PATH` | `~/.weave/fleet.db` (macOS/Linux), `%USERPROFILE%\.weave\fleet.db` (Windows) | SQLite database path |
+| `WEAVE_INSTALL_DIR` | `~/.weave/fleet` (macOS/Linux), `%LOCALAPPDATA%\weave\fleet` (Windows) | Installation directory (used by installer) |
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,6 +1167,111 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "dev": true,
@@ -11709,111 +11814,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/scripts/assemble-standalone.ps1
+++ b/scripts/assemble-standalone.ps1
@@ -1,0 +1,87 @@
+# assemble-standalone.ps1
+# Assembles the Next.js standalone output into a complete, runnable distribution.
+# Must be run after `next build` with `output: 'standalone'` in next.config.ts.
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+
+# Determine standalone directory — Turbopack may nest under the project name
+$StandaloneDir = $null
+
+$directServerJs = Join-Path $ProjectRoot ".next\standalone\server.js"
+if (Test-Path $directServerJs) {
+    $StandaloneDir = Join-Path $ProjectRoot ".next\standalone"
+}
+else {
+    # Find the nested directory (e.g., .next/standalone/weave-agent-fleet/)
+    $standaloneBase = Join-Path $ProjectRoot ".next\standalone"
+    if (Test-Path $standaloneBase) {
+        $nestedDirs = Get-ChildItem -Path $standaloneBase -Directory
+        foreach ($dir in $nestedDirs) {
+            $nestedServerJs = Join-Path $dir.FullName "server.js"
+            if (Test-Path $nestedServerJs) {
+                $StandaloneDir = $dir.FullName
+                break
+            }
+        }
+    }
+}
+
+if (-not $StandaloneDir -or -not (Test-Path (Join-Path $StandaloneDir "server.js"))) {
+    Write-Error "standalone server.js not found. Did you run 'next build' with output: 'standalone'?"
+    exit 1
+}
+
+Write-Host "Standalone directory: $StandaloneDir"
+
+# 1. Copy static assets (required by Next.js standalone mode)
+Write-Host "Copying .next/static/ ..."
+$staticSrc = Join-Path $ProjectRoot ".next\static"
+$staticDst = Join-Path $StandaloneDir ".next\static"
+if (Test-Path $staticSrc) {
+    New-Item -ItemType Directory -Path $staticDst -Force | Out-Null
+    Copy-Item -Path "$staticSrc\*" -Destination $staticDst -Recurse -Force
+}
+
+# 2. Copy public assets
+$publicSrc = Join-Path $ProjectRoot "public"
+if (Test-Path $publicSrc) {
+    Write-Host "Copying public/ ..."
+    $publicDst = Join-Path $StandaloneDir "public"
+    New-Item -ItemType Directory -Path $publicDst -Force | Out-Null
+    Copy-Item -Path "$publicSrc\*" -Destination $publicDst -Recurse -Force
+}
+
+# 3. Verify native addon for better-sqlite3
+$sqliteAddon = Join-Path $StandaloneDir "node_modules\better-sqlite3\build\Release\better_sqlite3.node"
+if (-not (Test-Path $sqliteAddon)) {
+    Write-Host "Warning: better-sqlite3 native addon missing from standalone output. Copying from node_modules..."
+    $srcAddon = Join-Path $ProjectRoot "node_modules\better-sqlite3\build\Release\better_sqlite3.node"
+    if (Test-Path $srcAddon) {
+        $addonDir = Split-Path -Parent $sqliteAddon
+        New-Item -ItemType Directory -Path $addonDir -Force | Out-Null
+        Copy-Item -Path $srcAddon -Destination $sqliteAddon -Force
+        Write-Host "Copied better-sqlite3 native addon."
+    }
+    else {
+        Write-Error "better-sqlite3 native addon not found in source node_modules either."
+        exit 1
+    }
+}
+
+# 4. Write VERSION file from package.json
+$packageJsonPath = Join-Path $ProjectRoot "package.json"
+try {
+    $packageJson = Get-Content $packageJsonPath -Raw | ConvertFrom-Json
+    $version = $packageJson.version
+}
+catch {
+    $version = "0.0.0"
+}
+Set-Content -Path (Join-Path $StandaloneDir "VERSION") -Value $version -NoNewline
+
+Write-Host "Assembly complete. Standalone directory is ready at: $StandaloneDir"
+Write-Host "  Version: $version"
+Write-Host "  Test with: node $StandaloneDir\server.js"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,224 @@
+# install.ps1 — Weave Agent Fleet installer for Windows
+# Usage: irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 | iex
+#
+# Environment variables:
+#   WEAVE_VERSION      — Install a specific version (e.g., "0.1.0"). Default: latest.
+#   WEAVE_INSTALL_DIR  — Installation directory. Default: %LOCALAPPDATA%\weave\fleet
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = "pgermishuys/weave-agent-fleet"
+$DefaultInstallDir = Join-Path $env:LOCALAPPDATA "weave\fleet"
+$InstallDir = if ($env:WEAVE_INSTALL_DIR) { $env:WEAVE_INSTALL_DIR } else { $DefaultInstallDir }
+
+# --- Helpers ---
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Green
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Yellow
+}
+
+function Write-ErrorAndExit {
+    param([string]$Message)
+    Write-Host "Error: $Message" -ForegroundColor Red
+    exit 1
+}
+
+# --- Detect architecture ---
+
+function Get-TargetArch {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        "AMD64" { return "x64" }
+        "ARM64" {
+            Write-ErrorAndExit "Windows ARM64 is not yet supported. See: https://github.com/$Repo/issues"
+        }
+        default {
+            Write-ErrorAndExit "Unsupported architecture: $arch. Only x64 is supported."
+        }
+    }
+}
+
+# --- Detect version ---
+
+function Get-LatestVersion {
+    if ($env:WEAVE_VERSION) {
+        Write-Info "Using specified version: v$($env:WEAVE_VERSION)"
+        return $env:WEAVE_VERSION
+    }
+
+    Write-Info "Fetching latest version..."
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+        $tag = $release.tag_name
+        $version = $tag -replace '^v', ''
+        if (-not $version) {
+            Write-ErrorAndExit "Could not determine latest version from GitHub API."
+        }
+        Write-Info "Latest version: v$version"
+        return $version
+    }
+    catch {
+        Write-ErrorAndExit "Failed to fetch latest release from GitHub. Check your internet connection.`n$($_.Exception.Message)"
+    }
+}
+
+# --- Verify checksum ---
+
+function Test-Checksum {
+    param(
+        [string]$FilePath,
+        [string]$ExpectedHash
+    )
+
+    $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLower()
+    $expected = $ExpectedHash.ToLower()
+
+    if ($actualHash -ne $expected) {
+        Write-ErrorAndExit "Checksum verification failed!`n  Expected: $expected`n  Actual:   $actualHash`nThe download may be corrupted. Please try again."
+    }
+}
+
+# --- Add to PATH ---
+
+function Add-ToUserPath {
+    param([string]$BinDir)
+
+    $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not $currentPath) {
+        $currentPath = ""
+    }
+
+    # Check if already in PATH
+    $paths = $currentPath -split ';' | Where-Object { $_ -ne '' }
+    $normalizedBinDir = $BinDir.TrimEnd('\')
+    $alreadyPresent = $paths | Where-Object { $_.TrimEnd('\') -eq $normalizedBinDir }
+
+    if ($alreadyPresent) {
+        return
+    }
+
+    $newPath = "$BinDir;$currentPath"
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    Write-Info "Added $BinDir to user PATH."
+}
+
+# --- Main ---
+
+function Main {
+    Write-Host ""
+    Write-Info "Weave Agent Fleet Installer (Windows)"
+    Write-Host ""
+
+    $arch = Get-TargetArch
+    $target = "windows-$arch"
+    $version = Get-LatestVersion
+
+    $zipName = "weave-fleet-v$version-$target.zip"
+    $downloadUrl = "https://github.com/$Repo/releases/download/v$version/$zipName"
+    $checksumsUrl = "https://github.com/$Repo/releases/download/v$version/checksums.txt"
+
+    # Create temp directory
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "weave-fleet-install-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    try {
+        # Download zip archive
+        $zipPath = Join-Path $tmpDir $zipName
+        Write-Info "Downloading $zipName..."
+        try {
+            Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
+        }
+        catch {
+            Write-ErrorAndExit "Failed to download $zipName. Check that a release exists for your platform ($target).`n$($_.Exception.Message)"
+        }
+
+        # Download and verify checksum
+        Write-Info "Verifying checksum..."
+        $checksumsPath = Join-Path $tmpDir "checksums.txt"
+        try {
+            Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksumsPath -UseBasicParsing
+            $checksumLine = Get-Content $checksumsPath | Where-Object { $_ -match [regex]::Escape($zipName) } | Select-Object -First 1
+            if ($checksumLine) {
+                $expectedHash = ($checksumLine -split '\s+')[0]
+                Test-Checksum -FilePath $zipPath -ExpectedHash $expectedHash
+                Write-Success "Checksum verified."
+            }
+            else {
+                Write-Warn "Warning: Checksum for $zipName not found in checksums.txt. Skipping verification."
+            }
+        }
+        catch [System.Net.WebException] {
+            Write-Warn "Warning: Could not download checksums.txt. Skipping verification."
+        }
+
+        # Remove existing installation
+        if (Test-Path $InstallDir) {
+            Write-Info "Removing existing installation at $InstallDir..."
+            Remove-Item -Recurse -Force $InstallDir
+        }
+
+        # Extract zip
+        Write-Info "Installing to $InstallDir..."
+        $extractDir = Join-Path $tmpDir "extracted"
+        Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+        # The zip extracts to a named directory — find it
+        $innerDir = Get-ChildItem -Path $extractDir -Directory | Where-Object { $_.Name -match "^weave-fleet-" } | Select-Object -First 1
+
+        if ($innerDir) {
+            # Move contents to install dir
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+            Copy-Item -Path "$($innerDir.FullName)\*" -Destination $InstallDir -Recurse -Force
+        }
+        else {
+            # Fallback: contents are directly in extract dir
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+            Copy-Item -Path "$extractDir\*" -Destination $InstallDir -Recurse -Force
+        }
+
+        # Add to PATH
+        $binDir = Join-Path $InstallDir "bin"
+        Add-ToUserPath -BinDir $binDir
+
+        Write-Host ""
+        Write-Success "Weave Fleet v$version installed successfully!"
+        Write-Host ""
+        Write-Host "  Install location: $InstallDir"
+        Write-Host "  Binary:           $binDir\weave-fleet.cmd"
+        Write-Host ""
+
+        # Check if opencode is available
+        $opencodeFound = Get-Command "opencode" -ErrorAction SilentlyContinue
+        if (-not $opencodeFound) {
+            Write-Warn "Note: OpenCode CLI is required but not found on PATH."
+            Write-Host "  Install it from: https://opencode.ai"
+            Write-Host ""
+        }
+
+        Write-Host "To get started:"
+        Write-Host ""
+        Write-Host "  1. Open a new terminal (PATH changes require a new session)"
+        Write-Host "  2. Run: weave-fleet"
+        Write-Host "  3. Open http://localhost:3000 in your browser"
+        Write-Host ""
+    }
+    finally {
+        # Clean up temp directory
+        if (Test-Path $tmpDir) {
+            Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,6 +38,14 @@ detect_platform() {
   case "$OS" in
     Darwin) PLATFORM="darwin" ;;
     Linux)  PLATFORM="linux" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      echo ""
+      warn "It looks like you're on Windows. Use the PowerShell installer instead:"
+      echo ""
+      echo "  irm https://github.com/${REPO}/releases/latest/download/install.ps1 | iex"
+      echo ""
+      exit 1
+      ;;
     *)      error "Unsupported operating system: $OS. Only macOS and Linux are supported." ;;
   esac
 

--- a/scripts/launcher.cmd
+++ b/scripts/launcher.cmd
@@ -1,0 +1,125 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem weave-fleet — launcher script for Weave Agent Fleet (Windows)
+rem Installed to %LOCALAPPDATA%\weave\fleet\bin\weave-fleet.cmd
+
+set "SCRIPT_DIR=%~dp0"
+rem Remove trailing backslash
+set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+rem Resolve install directory (parent of bin/)
+for %%I in ("%SCRIPT_DIR%\..") do set "INSTALL_DIR=%%~fI"
+
+set "NODE_BIN=%INSTALL_DIR%\bin\node.exe"
+set "SERVER_JS=%INSTALL_DIR%\app\server.js"
+set "VERSION_FILE=%INSTALL_DIR%\VERSION"
+
+rem Ensure bundled Node.js binary exists
+if not exist "%NODE_BIN%" (
+    echo Error: bundled Node.js binary not found at %NODE_BIN% >&2
+    echo Your installation may be corrupt. Re-install with: >&2
+    echo   irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 ^| iex >&2
+    exit /b 1
+)
+
+rem Ensure server.js exists
+if not exist "%SERVER_JS%" (
+    echo Error: server.js not found at %SERVER_JS% >&2
+    echo Your installation may be corrupt. Re-install with: >&2
+    echo   irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 ^| iex >&2
+    exit /b 1
+)
+
+rem Parse subcommands
+if "%~1"=="" goto :start_server
+if /i "%~1"=="version" goto :show_version
+if /i "%~1"=="--version" goto :show_version
+if /i "%~1"=="-v" goto :show_version
+if /i "%~1"=="update" goto :do_update
+if /i "%~1"=="uninstall" goto :do_uninstall
+if /i "%~1"=="help" goto :show_help
+if /i "%~1"=="--help" goto :show_help
+if /i "%~1"=="-h" goto :show_help
+
+echo Unknown command: %~1
+echo Run "weave-fleet help" for usage.
+exit /b 1
+
+:show_version
+if exist "%VERSION_FILE%" (
+    type "%VERSION_FILE%"
+) else (
+    echo unknown
+)
+exit /b 0
+
+:do_update
+echo Updating Weave Fleet...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 | iex"
+exit /b %ERRORLEVEL%
+
+:do_uninstall
+echo Removing Weave Fleet from %INSTALL_DIR%...
+rd /s /q "%INSTALL_DIR%" 2>nul
+echo Done.
+echo.
+echo You may need to remove the PATH entry manually:
+echo   1. Open Settings ^> System ^> About ^> Advanced system settings
+echo   2. Click "Environment Variables"
+echo   3. Under "User variables", edit "Path"
+echo   4. Remove the entry: %INSTALL_DIR%\bin
+exit /b 0
+
+:show_help
+set "VERSION=unknown"
+if exist "%VERSION_FILE%" (
+    set /p VERSION=<"%VERSION_FILE%"
+)
+echo Weave Fleet v!VERSION!
+echo.
+echo Usage: weave-fleet [command]
+echo.
+echo Commands:
+echo   (none)       Start the Weave Fleet server
+echo   version      Print the installed version
+echo   update       Update to the latest version
+echo   uninstall    Remove Weave Fleet
+echo   help         Show this help message
+echo.
+echo Environment variables:
+echo   PORT             Server port (default: 3000)
+echo   HOSTNAME         Server hostname (default: 0.0.0.0)
+echo   WEAVE_DB_PATH    Database file path (default: %%USERPROFILE%%\.weave\fleet.db)
+exit /b 0
+
+:start_server
+
+rem Check that opencode CLI is available
+where opencode >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+    echo Error: 'opencode' CLI not found on PATH. >&2
+    echo. >&2
+    echo Weave Fleet requires OpenCode to manage AI agent sessions. >&2
+    echo Install it from: https://opencode.ai >&2
+    exit /b 1
+)
+
+rem Set environment for production
+set "NODE_ENV=production"
+if not defined PORT set "PORT=3000"
+if not defined HOSTNAME set "HOSTNAME=0.0.0.0"
+
+rem Ensure data directory exists
+if not exist "%USERPROFILE%\.weave" mkdir "%USERPROFILE%\.weave"
+
+set "VERSION=unknown"
+if exist "%VERSION_FILE%" (
+    set /p VERSION=<"%VERSION_FILE%"
+)
+
+echo Weave Fleet v!VERSION! starting on http://localhost:!PORT!
+
+rem Start the server
+rem On Windows, Ctrl+C is handled natively by the console — Node.js receives SIGINT directly
+"%NODE_BIN%" "%SERVER_JS%"

--- a/src/lib/server/process-manager.ts
+++ b/src/lib/server/process-manager.ts
@@ -15,7 +15,7 @@
 import { createOpencodeServer, createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2";
 import { statSync } from "fs";
 import { homedir } from "os";
-import { resolve } from "path";
+import { resolve, sep } from "path";
 import { randomUUID } from "crypto";
 import {
   insertInstance,
@@ -72,7 +72,8 @@ let _cleanupRun = false;
 function getAllowedRoots(): string[] {
   const envRoots = process.env.ORCHESTRATOR_WORKSPACE_ROOTS;
   if (envRoots) {
-    return envRoots.split(":").map((r) => resolve(r.trim())).filter(Boolean);
+    const separator = process.platform === "win32" ? ";" : ":";
+    return envRoots.split(separator).map((r) => resolve(r.trim())).filter(Boolean);
   }
   return [resolve(homedir())];
 }
@@ -90,7 +91,7 @@ export function validateDirectory(directory: string): string {
 
   const roots = getAllowedRoots();
   const underAllowedRoot = roots.some(
-    (root) => resolved === root || resolved.startsWith(root + "/")
+    (root) => resolved === root || resolved.startsWith(root + sep)
   );
   if (!underAllowedRoot) {
     throw new Error("Directory is outside the allowed workspace roots");


### PR DESCRIPTION
## Summary

- Add complete Windows x64 support for the Weave Agent Fleet installer and binary distribution pipeline
- Includes PowerShell installer (`install.ps1`), Windows `.cmd` launcher, CI assembly script, and release workflow updates
- Fixes runtime path separator bugs in `process-manager.ts` for Windows compatibility

## Changes

### New files
- **`scripts/install.ps1`** — PowerShell installer supporting `irm https://get.tryweave.io/install.ps1 | iex` one-liner. Downloads zip from GitHub Releases, verifies SHA256, extracts to `~/.weave/fleet/`, adds to User PATH via registry.
- **`scripts/launcher.cmd`** — Windows `.cmd` launcher with subcommands: `version`, `update`, `uninstall`, `help`, `start`. Resolves bundled Node.js, sets environment variables, launches the Next.js server.
- **`scripts/assemble-standalone.ps1`** — PowerShell CI assembly script that copies static assets, verifies `better-sqlite3` native addon, writes VERSION file.

### Modified files
- **`.github/workflows/release.yml`** — Added `windows-x64` matrix entry running on `windows-latest`. OS-specific guards (`if: runner.os != 'Windows'` / `if: runner.os == 'Windows'`) for shell scripts vs PowerShell. Windows builds produce `.zip` + `.zip.sha256` artifacts.
- **`scripts/install.sh`** — Detects MINGW/MSYS/CYGWIN environments and redirects Windows users to the PowerShell installer with a helpful message.
- **`src/lib/server/process-manager.ts`** — Fixed `ORCHESTRATOR_WORKSPACE_ROOTS` to split on `;` (Windows) vs `:` (Unix). Fixed `path.sep` usage instead of hardcoded `/` for path resolution.
- **`README.md`** — Added Windows PowerShell install instructions and updated configuration table with Windows default paths.
- **`.gitignore`** — Added `weave-fleet-*.zip` and `weave-fleet-*.zip.sha256` patterns.

## Verification

- ✅ Lint: 0 errors
- ✅ TypeScript: clean typecheck
- ✅ Tests: 322/322 passing

## Notes

- Windows arm64 is documented as future work via a comment in `release.yml`
- `package-lock.json` change is a harmless reorder of `@next/swc-*` optional platform entries