### PR TITLE
feat: add vanity URL distribution via GitHub Pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,3 +237,40 @@ jobs:
             artifacts/checksums.txt
             scripts/install.sh
             scripts/install.ps1
+
+  deploy-vanity-url:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          path: source
+
+      - name: Update scripts on gh-pages
+        run: |
+          cp source/scripts/install.sh gh-pages/agent-fleet.sh
+          if [ -f source/scripts/install.ps1 ]; then
+            cp source/scripts/install.ps1 gh-pages/agent-fleet.ps1
+          fi
+
+      - name: Commit and push
+        working-directory: gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add agent-fleet.sh agent-fleet.ps1 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No changes to deploy"
+          else
+            git commit -m "Update install scripts for ${GITHUB_REF_NAME}"
+            git push
+          fi

--- a/.weave/plans/vanity-url-distribution.md
+++ b/.weave/plans/vanity-url-distribution.md
@@ -91,7 +91,7 @@ Serve install scripts at `https://get.tryweave.io/agent-fleet.sh` and `https://g
   **Files**: None (DNS console)
   **Acceptance**: `dig get.tryweave.io CNAME` returns `pgermishuys.github.io.`
 
-- [ ] 2. **Initialize the `gh-pages` branch with CNAME file**
+- [x] 2. **Initialize the `gh-pages` branch with CNAME file**
   **What**: Create an orphan `gh-pages` branch with:
   - `CNAME` file containing `get.tryweave.io` (tells GitHub Pages to serve this custom domain)
   - `.nojekyll` empty file (disables Jekyll processing — we want raw file serving)
@@ -138,7 +138,7 @@ Serve install scripts at `https://get.tryweave.io/agent-fleet.sh` and `https://g
 
 ### Phase 2: Automated Deployment
 
-- [ ] 4. **Add deploy-to-gh-pages step in release workflow**
+- [x] 4. **Add deploy-to-gh-pages step in release workflow**
   **What**: Add a new job to `.github/workflows/release.yml` that runs after the `release` job and copies the install scripts to the `gh-pages` branch. This ensures the vanity URL always serves the latest release's scripts.
 
   Add a `deploy-vanity-url` job:
@@ -184,7 +184,7 @@ Serve install scripts at `https://get.tryweave.io/agent-fleet.sh` and `https://g
 
 ### Phase 3: Update References in Scripts
 
-- [ ] 5. **Update `scripts/install.sh` header comment**
+- [x] 5. **Update `scripts/install.sh` header comment**
   **What**: Change the usage comment from the GitHub Releases URL to the vanity URL:
   ```sh
   # Usage: curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh
@@ -193,7 +193,7 @@ Serve install scripts at `https://get.tryweave.io/agent-fleet.sh` and `https://g
   **Files**: `scripts/install.sh` (line 3)
   **Acceptance**: The comment at the top of `install.sh` shows the vanity URL.
 
-- [ ] 6. **Update `scripts/launcher.sh` error messages and update URL**
+- [x] 6. **Update `scripts/launcher.sh` error messages and update URL**
   **What**: Update three locations where the GitHub Releases `install.sh` URL is hardcoded:
   
   Line 16 (Node.js binary not found error):
@@ -218,7 +218,7 @@ Serve install scripts at `https://get.tryweave.io/agent-fleet.sh` and `https://g
   **Files**: `scripts/launcher.sh` (lines 16, 24, 41, 43)
   **Acceptance**: All self-referencing URLs in the launcher use the vanity URL. `weave-fleet update` downloads from `get.tryweave.io`.
 
-- [ ] 7. **Update `README.md` install instructions**
+- [x] 7. **Update `README.md` install instructions**
   **What**: Replace the install command with the vanity URL:
   ```markdown
   ### Install
@@ -234,7 +234,7 @@ Serve install scripts at `https://get.tryweave.io/agent-fleet.sh` and `https://g
 
 ### Phase 4: Update Windows Plan
 
-- [ ] 8. **Update `windows-installer-support.md` with vanity URLs**
+- [x] 8. **Update `windows-installer-support.md` with vanity URLs**
   **What**: Update all references to the raw GitHub Releases URLs in the Windows plan to use vanity URLs:
   
   - Line 58 (Definition of Done): `irm https://get.tryweave.io/agent-fleet.ps1 | iex`
@@ -257,7 +257,7 @@ Serve install scripts at `https://get.tryweave.io/agent-fleet.sh` and `https://g
   **Files**: `.weave/plans/windows-installer-support.md`
   **Acceptance**: All install URLs in the Windows plan use `get.tryweave.io` vanity URLs.
 
-- [ ] 9. **Add vanity URL note to the Windows install.ps1 task**
+- [x] 9. **Add vanity URL note to the Windows install.ps1 task**
   **What**: When `scripts/install.ps1` is eventually implemented (per the Windows plan), ensure it includes the vanity URL in its header comment:
   ```powershell
   # Usage: irm https://get.tryweave.io/agent-fleet.ps1 | iex

--- a/.weave/plans/windows-installer-support.md
+++ b/.weave/plans/windows-installer-support.md
@@ -55,7 +55,7 @@ Ship Windows x64 as a supported platform with a PowerShell one-liner installer (
 - [ ] `.gitignore` updated for Windows build artifacts
 
 ### Definition of Done
-- [ ] `irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 | iex` successfully installs on a clean Windows x64 machine
+- [ ] `irm https://get.tryweave.io/agent-fleet.ps1 | iex` successfully installs on a clean Windows x64 machine
 - [ ] `weave-fleet` starts the Next.js production server on Windows
 - [ ] `weave-fleet update` re-installs the latest version on Windows
 - [ ] `weave-fleet version` prints the correct version on Windows
@@ -77,7 +77,7 @@ Ship Windows x64 as a supported platform with a PowerShell one-liner installer (
 ### Phase 1: PowerShell Install Script
 
 - [ ] 1. **Create `scripts/install.ps1`**
-  **What**: PowerShell install script equivalent to `install.sh`. Invoked via `irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 | iex`. Must:
+  **What**: PowerShell install script equivalent to `install.sh`. Invoked via `irm https://get.tryweave.io/agent-fleet.ps1 | iex`. Must:
   - Detect architecture via `$env:PROCESSOR_ARCHITECTURE` (map `AMD64`→`x64`, `ARM64`→`arm64`)
   - Only support `x64` initially; error on `ARM64` with "Windows arm64 not yet supported"
   - Determine latest version from GitHub Releases API (`Invoke-RestMethod`) or use `$env:WEAVE_VERSION`
@@ -99,7 +99,7 @@ Ship Windows x64 as a supported platform with a PowerShell one-liner installer (
   **What**: Add a check at the top of `install.sh` to detect Windows environments (MSYS, Git Bash, Cygwin, WSL running Windows binaries) and print a redirect message:
   ```
   It looks like you're on Windows. Use the PowerShell installer instead:
-    irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 | iex
+    irm https://get.tryweave.io/agent-fleet.ps1 | iex
   ```
   Detection: Check `uname -s` for `MINGW*`, `MSYS*`, `CYGWIN*` patterns. Keep the existing `*) error "Unsupported..."` as fallback.
   **Files**: `scripts/install.sh`
@@ -117,7 +117,7 @@ Ship Windows x64 as a supported platform with a PowerShell one-liner installer (
   - Parse first argument as subcommand:
     - `(no args)` — start the server
     - `version` / `--version` / `-v` — print VERSION file content
-    - `update` — invoke PowerShell: `powershell -NoProfile -Command "irm <install.ps1 URL> | iex"`
+    - `update` — invoke PowerShell: `powershell -NoProfile -Command "irm https://get.tryweave.io/agent-fleet.ps1 | iex"`
     - `uninstall` — remove `%INSTALL_DIR%` and print manual PATH removal instructions
     - `help` / `--help` / `-h` — print usage
   - Check `opencode` is on PATH via `where opencode >nul 2>nul`; error if not found
@@ -251,15 +251,15 @@ Ship Windows x64 as a supported platform with a PowerShell one-liner installer (
   ```markdown
   ### Install
   
-  **macOS / Linux:**
-  ```sh
-  curl -fsSL https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh
-  ```
-  
-  **Windows (PowerShell):**
-  ```powershell
-  irm https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.ps1 | iex
-  ```
+   **macOS / Linux:**
+   ```sh
+   curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh
+   ```
+   
+   **Windows (PowerShell):**
+   ```powershell
+   irm https://get.tryweave.io/agent-fleet.ps1 | iex
+   ```
   ```
   Also update the Configuration table to add Windows-specific defaults:
   - `WEAVE_INSTALL_DIR`: `~/.weave/fleet` (macOS/Linux), `%LOCALAPPDATA%\weave\fleet` (Windows)
@@ -351,7 +351,7 @@ Phases 5 and 6 are independent of each other and can be done in parallel. Phase 
 **Mitigation**: `node.exe` from nodejs.org is signed. The `.zip` archive is downloaded from GitHub Releases (trusted source). If users report issues, document adding an AV exclusion for `%LOCALAPPDATA%\weave\fleet\`.
 
 ## Verification
-- [ ] `irm <install.ps1 URL> | iex` installs on a clean Windows x64 machine
+- [ ] `irm https://get.tryweave.io/agent-fleet.ps1 | iex` installs on a clean Windows x64 machine
 - [ ] `weave-fleet` starts the server on Windows (http://localhost:3000 responds)
 - [ ] `weave-fleet version` prints the correct version
 - [ ] `weave-fleet update` downloads and installs the latest release

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A fleet orchestrator for managing multiple OpenCode AI agent sessions from a sin
 **macOS / Linux:**
 
 ```sh
-curl -fsSL https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh
+curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh
 ```
 
 **Windows (PowerShell):**

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # install.sh — Weave Agent Fleet installer
-# Usage: curl -fsSL https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh
+# Usage: curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh
 #
 # Environment variables:
 #   WEAVE_VERSION      — Install a specific version (e.g., "0.1.0"). Default: latest.

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -13,7 +13,7 @@ VERSION_FILE="$INSTALL_DIR/VERSION"
 if [ ! -x "$NODE_BIN" ]; then
   echo "Error: bundled Node.js binary not found at $NODE_BIN" >&2
   echo "Your installation may be corrupt. Re-install with:" >&2
-  echo "  curl -fsSL https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh" >&2
+  echo "  curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh" >&2
   exit 1
 fi
 
@@ -21,7 +21,7 @@ fi
 if [ ! -f "$SERVER_JS" ]; then
   echo "Error: server.js not found at $SERVER_JS" >&2
   echo "Your installation may be corrupt. Re-install with:" >&2
-  echo "  curl -fsSL https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh" >&2
+  echo "  curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh" >&2
   exit 1
 fi
 
@@ -38,9 +38,9 @@ case "${1:-}" in
   update)
     echo "Updating Weave Fleet..."
     if command -v curl >/dev/null 2>&1; then
-      exec sh -c "curl -fsSL https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh"
+      exec sh -c "curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh"
     elif command -v wget >/dev/null 2>&1; then
-      exec sh -c "wget -qO- https://github.com/pgermishuys/weave-agent-fleet/releases/latest/download/install.sh | sh"
+      exec sh -c "wget -qO- https://get.tryweave.io/agent-fleet.sh | sh"
     else
       echo "Error: curl or wget is required to update." >&2
       exit 1


### PR DESCRIPTION
## Summary

- Set up `get.tryweave.io` as a vanity URL endpoint for install scripts, served directly via GitHub Pages with automated deployment on release
- Initialize `gh-pages` branch with `CNAME`, `.nojekyll`, `agent-fleet.sh`, and `index.html`
- Add `deploy-vanity-url` job to release workflow that syncs `scripts/install.sh` (and `install.ps1` when present) to `gh-pages` on each release
- Update all install/launcher/README references from long GitHub Releases URLs to `https://get.tryweave.io/agent-fleet.sh`
- Update Windows installer plan references to use `https://get.tryweave.io/agent-fleet.ps1`

## Manual Steps Required After Merge

1. **DNSimple**: Add CNAME record `get` → `pgermishuys.github.io` (TTL 3600)
2. **GitHub Pages**: Settings → Pages → Source: `gh-pages` branch, Custom domain: `get.tryweave.io`, Enforce HTTPS ✅

## Result

```sh
# macOS/Linux
curl -fsSL https://get.tryweave.io/agent-fleet.sh | sh

# Windows
irm https://get.tryweave.io/agent-fleet.ps1 | iex
```