### PR TITLE
feat: add draggable resize handle to sidebar

### DIFF
--- a/src/components/layout/sidebar-session-item.tsx
+++ b/src/components/layout/sidebar-session-item.tsx
@@ -42,7 +42,7 @@ export function SidebarSessionItem({ item, isActive, isChild = false }: SidebarS
     >
       {isChild && <span className="text-muted-foreground/50 text-[10px] shrink-0">↳</span>}
       <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${dotColor}`} />
-      <span className="truncate max-w-[120px]">{title}</span>
+      <span className="truncate">{title}</span>
     </Link>
   );
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -30,7 +30,13 @@ import { useNotifications } from "@/contexts/notifications-context";
 import { useSessionsContext } from "@/contexts/sessions-context";
 import { useWorkspaces } from "@/hooks/use-workspaces";
 import { usePersistedState } from "@/hooks/use-persisted-state";
-import { useSidebar } from "@/contexts/sidebar-context";
+import {
+  useSidebar,
+  SIDEBAR_COLLAPSED_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+} from "@/contexts/sidebar-context";
+import { useSidebarResize } from "@/hooks/use-sidebar-resize";
 import { SidebarWorkspaceItem } from "@/components/layout/sidebar-workspace-item";
 
 const FLEET_EXPANDED_KEY = "weave:sidebar:fleet-expanded";
@@ -40,13 +46,49 @@ export function Sidebar() {
   const { unreadCount } = useNotifications();
   const { sessions, error } = useSessionsContext();
   const workspaces = useWorkspaces(sessions);
-  const { collapsed, toggleSidebar } = useSidebar();
+  const {
+    collapsed,
+    toggleSidebar,
+    width,
+    setWidth,
+    isResizing,
+    setIsResizing,
+  } = useSidebar();
   const [fleetExpanded, setFleetExpanded] = usePersistedState<boolean>(
     FLEET_EXPANDED_KEY,
     true
   );
 
   const treeRef = useRef<HTMLDivElement>(null);
+
+  const handleResizeStart = useCallback(() => {
+    setIsResizing(true);
+  }, [setIsResizing]);
+
+  const handleResize = useCallback(
+    (newWidth: number) => {
+      setWidth(newWidth);
+    },
+    [setWidth]
+  );
+
+  const handleResizeEnd = useCallback(
+    (finalWidth: number) => {
+      setWidth(finalWidth);
+      setIsResizing(false);
+    },
+    [setWidth, setIsResizing]
+  );
+
+  const { handlePointerDown, handlePointerMove, handlePointerUp } =
+    useSidebarResize({
+      minWidth: SIDEBAR_MIN_WIDTH,
+      maxWidth: SIDEBAR_MAX_WIDTH,
+      onResize: handleResize,
+      onResizeEnd: handleResizeEnd,
+      onResizeStart: handleResizeStart,
+      disabled: collapsed,
+    });
 
   // Keyboard navigation handler for the tree
   const handleTreeKeyDown = useCallback(
@@ -136,12 +178,15 @@ export function Sidebar() {
 
   const isFleetActive = pathname === "/" || pathname.startsWith("/?");
 
+  const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : width;
+
   return (
     <aside
       className={cn(
-        "flex h-screen flex-col border-r border-sidebar-border bg-sidebar overflow-hidden transition-all duration-200 ease-in-out",
-        collapsed ? "w-16" : "w-56"
+        "relative flex h-screen flex-col border-r border-sidebar-border bg-sidebar overflow-hidden",
+        !isResizing && "transition-all duration-200 ease-in-out"
       )}
+      style={{ width: sidebarWidth }}
     >
       {/* Weave branding */}
       <Link
@@ -417,6 +462,30 @@ export function Sidebar() {
           </Tooltip>
         )}
       </div>
+
+      {/* Resize handle */}
+      {!collapsed && (
+        <div
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onDoubleClick={toggleSidebar}
+          className="group absolute top-0 right-0 h-full w-1.5 cursor-col-resize z-10"
+          aria-label="Resize sidebar"
+          role="separator"
+          aria-orientation="vertical"
+        >
+          {/* Visual indicator line */}
+          <div
+            className={cn(
+              "absolute top-0 right-0 h-full w-0.5 transition-opacity duration-150",
+              isResizing
+                ? "bg-primary opacity-100"
+                : "bg-primary/40 opacity-0 group-hover:opacity-100"
+            )}
+          />
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -4,17 +4,28 @@ import {
   createContext,
   useCallback,
   useContext,
+  useState,
   type ReactNode,
 } from "react";
 import { usePersistedState } from "@/hooks/use-persisted-state";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 
 const SIDEBAR_COLLAPSED_KEY = "weave:sidebar:collapsed";
+const SIDEBAR_WIDTH_KEY = "weave:sidebar:width";
+
+export const SIDEBAR_MIN_WIDTH = 180;
+export const SIDEBAR_MAX_WIDTH = 480;
+export const SIDEBAR_COLLAPSED_WIDTH = 64;
+export const SIDEBAR_DEFAULT_WIDTH = 224;
 
 interface SidebarContextValue {
   collapsed: boolean;
   setCollapsed: (value: boolean | ((prev: boolean) => boolean)) => void;
   toggleSidebar: () => void;
+  width: number;
+  setWidth: (value: number | ((prev: number) => number)) => void;
+  isResizing: boolean;
+  setIsResizing: (value: boolean) => void;
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
@@ -29,6 +40,13 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
     false
   );
 
+  const [width, setWidth] = usePersistedState<number>(
+    SIDEBAR_WIDTH_KEY,
+    SIDEBAR_DEFAULT_WIDTH
+  );
+
+  const [isResizing, setIsResizing] = useState(false);
+
   const toggleSidebar = useCallback(() => {
     setCollapsed((prev) => !prev);
   }, [setCollapsed]);
@@ -37,7 +55,17 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
   useKeyboardShortcut("b", toggleSidebar, { platformModifier: true });
 
   return (
-    <SidebarContext.Provider value={{ collapsed, setCollapsed, toggleSidebar }}>
+    <SidebarContext.Provider
+      value={{
+        collapsed,
+        setCollapsed,
+        toggleSidebar,
+        width,
+        setWidth,
+        isResizing,
+        setIsResizing,
+      }}
+    >
       {children}
     </SidebarContext.Provider>
   );

--- a/src/hooks/use-sidebar-resize.ts
+++ b/src/hooks/use-sidebar-resize.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useRef, useCallback, useEffect } from "react";
+
+interface UseSidebarResizeOptions {
+  minWidth: number;
+  maxWidth: number;
+  onResize: (width: number) => void;
+  onResizeEnd: (width: number) => void;
+  onResizeStart: () => void;
+  disabled?: boolean;
+}
+
+export function useSidebarResize({
+  minWidth,
+  maxWidth,
+  onResize,
+  onResizeEnd,
+  onResizeStart,
+  disabled = false,
+}: UseSidebarResizeOptions) {
+  const isResizingRef = useRef(false);
+  const latestWidthRef = useRef(0);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      isResizingRef.current = true;
+      onResizeStart();
+
+      // Capture pointer to receive events even outside the element
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+
+      // Prevent text selection and set resize cursor globally
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [disabled, onResizeStart]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!isResizingRef.current) return;
+      e.preventDefault();
+
+      const newWidth = Math.round(
+        Math.min(maxWidth, Math.max(minWidth, e.clientX))
+      );
+      latestWidthRef.current = newWidth;
+      onResize(newWidth);
+    },
+    [minWidth, maxWidth, onResize]
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!isResizingRef.current) return;
+
+      isResizingRef.current = false;
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+
+      // Restore normal cursor and selection
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+
+      onResizeEnd(latestWidthRef.current);
+    },
+    [onResizeEnd]
+  );
+
+  // Safety cleanup on unmount
+  useEffect(() => {
+    return () => {
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, []);
+
+  return {
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #29

- Adds a draggable resize handle on the right edge of the sidebar, allowing users to set any width between 180–480px
- Persists the user's preferred width to `localStorage` (`weave:sidebar:width`) across page reloads
- Retains the existing `Cmd+B` collapse/expand toggle — collapsing snaps to 64px, expanding restores the last user-set width
- Disables CSS transitions during active drag for smooth, jank-free resizing
- Double-click on the resize handle toggles collapse (VS Code-style)
- Removes hardcoded `max-w-[120px]` on session titles so they expand to fill available space

## Changes

| File | What |
|---|---|
| `src/hooks/use-sidebar-resize.ts` | **New** — custom hook with pointer-event drag logic, cursor management, and text selection prevention |
| `src/contexts/sidebar-context.tsx` | Extended with `width`, `setWidth`, `isResizing` state + exported width constants |
| `src/components/layout/sidebar.tsx` | Replaced Tailwind width classes with inline `style={{ width }}`, added resize handle element |
| `src/components/layout/sidebar-session-item.tsx` | Removed `max-w-[120px]` so titles flex with sidebar width |

## Implementation Notes

- **No new dependencies** — custom ~80-line hook instead of `react-resizable-panels`
- Uses pointer capture for reliable drag tracking even when cursor leaves the handle
- Handle is a 6px invisible hit zone with a 2px visual indicator that appears on hover (primary/40 opacity) and during drag (full primary)
- `collapsed` boolean remains the sole driver for icon-only vs. full rendering — width is independent