### PR TITLE
feat: add command palette with configurable keybindings

### DIFF
--- a/src/app/client-layout.tsx
+++ b/src/app/client-layout.tsx
@@ -3,20 +3,34 @@
 import { SessionsProvider } from "@/contexts/sessions-context";
 import { NotificationsProvider } from "@/contexts/notifications-context";
 import { SidebarProvider } from "@/contexts/sidebar-context";
+import { KeybindingsProvider } from "@/contexts/keybindings-context";
+import { CommandRegistryProvider } from "@/contexts/command-registry-context";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Sidebar } from "@/components/layout/sidebar";
+import { NavigationCommands } from "@/components/commands/navigation-commands";
+import { ViewCommands } from "@/components/commands/view-commands";
+import { SessionCommands } from "@/components/commands/session-commands";
+import { CommandPalette } from "@/components/command-palette";
 
 export function ClientLayout({ children }: { children: React.ReactNode }) {
   return (
     <SessionsProvider>
       <NotificationsProvider>
         <SidebarProvider>
-          <TooltipProvider delayDuration={0}>
-            <div className="flex h-screen overflow-hidden">
-              <Sidebar />
-              <main className="flex-1 overflow-auto">{children}</main>
-            </div>
-          </TooltipProvider>
+          <KeybindingsProvider>
+            <CommandRegistryProvider>
+              <TooltipProvider delayDuration={0}>
+                <div className="flex h-screen overflow-hidden">
+                  <Sidebar />
+                  <main className="flex-1 overflow-auto">{children}</main>
+                </div>
+              </TooltipProvider>
+              <NavigationCommands />
+              <ViewCommands />
+              <SessionCommands />
+              <CommandPalette />
+            </CommandRegistryProvider>
+          </KeybindingsProvider>
         </SidebarProvider>
       </NotificationsProvider>
     </SessionsProvider>

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -9,12 +9,12 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { useSessionEvents } from "@/hooks/use-session-events";
 import { useSendPrompt } from "@/hooks/use-send-prompt";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAgents } from "@/hooks/use-agents";
 import { useDiffs } from "@/hooks/use-diffs";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { FolderOpen, GitBranch, GitCompare, Server, Clock, Hash, Coins, Square, RotateCcw, Trash2, ExternalLink } from "lucide-react";
+import { FolderOpen, GitBranch, GitCompare, Server, Clock, Hash, Coins, Square, RotateCcw, Trash2, ExternalLink, MessageSquare } from "lucide-react";
 import { useTerminateSession } from "@/hooks/use-terminate-session";
 import { useResumeSession } from "@/hooks/use-resume-session";
 import { useDeleteSession } from "@/hooks/use-delete-session";
@@ -23,6 +23,8 @@ import { ConfirmDeleteSessionDialog } from "@/components/fleet/confirm-delete-se
 import { extractLatestTodos } from "@/lib/todo-utils";
 import { TodoSidebarPanel } from "@/components/session/todo-sidebar-panel";
 import { DiffViewer } from "@/components/session/diff-viewer";
+import { useCommandRegistry } from "@/contexts/command-registry-context";
+import { useKeybindings } from "@/contexts/keybindings-context";
 
 interface SessionMetadata {
   workspaceId: string | null;
@@ -58,6 +60,28 @@ export default function SessionDetailPage() {
   const [stopConfirm, setStopConfirm] = useState(false);
   const [isResumable, setIsResumable] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const promptFocusRef = useRef<(() => void) | null>(null);
+  const { registerCommand, unregisterCommand } = useCommandRegistry();
+  const { bindings } = useKeybindings();
+
+  // Register "Focus Prompt Input" command for this session page
+  useEffect(() => {
+    registerCommand({
+      id: "focus-prompt",
+      label: "Focus Prompt Input",
+      icon: MessageSquare,
+      category: "Session",
+      paletteHotkey: bindings["focus-prompt"]?.paletteHotkey ?? undefined,
+      keywords: ["message", "chat", "type", "input"],
+      action: () => {
+        promptFocusRef.current?.();
+      },
+    });
+    return () => {
+      unregisterCommand("focus-prompt");
+    };
+  }, [registerCommand, unregisterCommand, bindings]);
 
   const [metadata, setMetadata] = useState<SessionMetadata>({
     workspaceId: null,
@@ -317,6 +341,9 @@ export default function SessionDetailPage() {
                 agents={agents}
                 selectedAgent={selectedAgent}
                 onAgentChange={setSelectedAgent}
+                onFocusRequest={(focus) => {
+                  promptFocusRef.current = focus;
+                }}
               />
             </TabsContent>
             <TabsContent value="changes" className="flex-1 overflow-hidden">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,17 +6,19 @@ import { SkillsTab } from "@/components/settings/skills-tab";
 import { AgentsTab } from "@/components/settings/agents-tab";
 import { NotificationsTab } from "@/components/settings/notifications-tab";
 import { AboutTab } from "@/components/settings/about-tab";
+import { KeybindingsTab } from "@/components/settings/keybindings-tab";
 
 export default function SettingsPage() {
   return (
     <div className="flex flex-col h-full">
-      <Header title="Settings" subtitle="Manage skills, agents, notifications, and configuration" />
+      <Header title="Settings" subtitle="Manage skills, agents, notifications, keybindings, and configuration" />
       <div className="flex-1 overflow-auto p-6">
         <Tabs defaultValue="skills">
           <TabsList variant="line">
             <TabsTrigger value="skills">Skills</TabsTrigger>
             <TabsTrigger value="agents">Agents</TabsTrigger>
             <TabsTrigger value="notifications">Notifications</TabsTrigger>
+            <TabsTrigger value="keybindings">Keybindings</TabsTrigger>
             <TabsTrigger value="about">About</TabsTrigger>
           </TabsList>
           <TabsContent value="skills" className="mt-4">
@@ -27,6 +29,9 @@ export default function SettingsPage() {
           </TabsContent>
           <TabsContent value="notifications" className="mt-4">
             <NotificationsTab />
+          </TabsContent>
+          <TabsContent value="keybindings" className="mt-4">
+            <KeybindingsTab />
           </TabsContent>
           <TabsContent value="about" className="mt-4">
             <AboutTab />

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useCommandRegistry } from "@/contexts/command-registry-context";
+import type { Command, CommandCategory } from "@/lib/command-registry";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from "@/components/ui/command";
+
+function formatGlobalShortcut(gs: NonNullable<Command["globalShortcut"]>): string {
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+  let modifier = "";
+  if (gs.platformModifier) {
+    modifier = isMac ? "⌘" : "Ctrl+";
+  } else if (gs.metaKey) {
+    modifier = "⌘";
+  } else if (gs.ctrlKey) {
+    modifier = "Ctrl+";
+  }
+
+  const key = gs.key.toUpperCase();
+  return `${modifier}${key}`;
+}
+
+const CATEGORY_ORDER: CommandCategory[] = ["Session", "Navigation", "View"];
+
+export function CommandPalette() {
+  const { commands, paletteOpen, setPaletteOpen } = useCommandRegistry();
+  const [search, setSearch] = useState("");
+
+  // Reset search when palette closes
+  useEffect(() => {
+    if (!paletteOpen) {
+      setSearch("");
+    }
+  }, [paletteOpen]);
+
+  // Group commands by category
+  const grouped = CATEGORY_ORDER.map((category) => ({
+    category,
+    items: commands.filter((c) => c.category === category),
+  })).filter((g) => g.items.length > 0);
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const isMac =
+      typeof navigator !== "undefined" &&
+      /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+    // Cmd+K / Ctrl+K closes the palette when inside the input
+    if (e.key === "k" && (isMac ? e.metaKey : e.ctrlKey)) {
+      e.preventDefault();
+      setPaletteOpen(false);
+      return;
+    }
+
+    // Only intercept single-char palette hotkeys when search is empty and no modifiers
+    if (search === "" && !e.metaKey && !e.ctrlKey && !e.altKey && e.key.length === 1) {
+      for (const command of commands) {
+        if (
+          command.paletteHotkey === e.key &&
+          !command.disabled
+        ) {
+          e.preventDefault();
+          command.action();
+          setPaletteOpen(false);
+          return;
+        }
+      }
+    }
+  };
+
+  return (
+    <CommandDialog
+      open={paletteOpen}
+      onOpenChange={setPaletteOpen}
+      title="Command Palette"
+      description="Search for a command to run..."
+      showCloseButton={false}
+    >
+      <CommandInput
+        value={search}
+        onValueChange={setSearch}
+        placeholder="Type a command or search..."
+        onKeyDown={handleInputKeyDown}
+      />
+      <CommandList>
+        <CommandEmpty>No commands found.</CommandEmpty>
+        {grouped.map(({ category, items }) => (
+          <CommandGroup key={category} heading={category}>
+            {items.map((command) => {
+              const Icon = command.icon;
+              return (
+                <CommandItem
+                  key={command.id}
+                  value={[command.label, ...(command.keywords ?? [])].join(" ")}
+                  disabled={command.disabled}
+                  data-disabled={command.disabled ? "true" : undefined}
+                  onSelect={() => {
+                    if (command.disabled) return;
+                    command.action();
+                    setPaletteOpen(false);
+                  }}
+                >
+                  {Icon && <Icon />}
+                  <span>{command.label}</span>
+                  {(command.globalShortcut || command.paletteHotkey) && (
+                    <CommandShortcut>
+                      {command.globalShortcut ? (
+                        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+                          {formatGlobalShortcut(command.globalShortcut)}
+                        </kbd>
+                      ) : command.paletteHotkey ? (
+                        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+                          {command.paletteHotkey}
+                        </kbd>
+                      ) : null}
+                    </CommandShortcut>
+                  )}
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        ))}
+      </CommandList>
+      {/* Footer with keyboard hints */}
+      <div className="flex items-center justify-between border-t px-3 py-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-3">
+          <span>
+            <kbd className="font-mono">↑↓</kbd> Navigate
+          </span>
+          <span>
+            <kbd className="font-mono">↵</kbd> Select
+          </span>
+          <span>
+            <kbd className="font-mono">Esc</kbd> Close
+          </span>
+        </div>
+        <span className="opacity-50">
+          <kbd className="font-mono">⌘K</kbd> toggle
+        </span>
+      </div>
+    </CommandDialog>
+  );
+}

--- a/src/components/commands/navigation-commands.tsx
+++ b/src/components/commands/navigation-commands.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { LayoutGrid, Settings, Bell, History } from "lucide-react";
+import { useCommandRegistry } from "@/contexts/command-registry-context";
+import { useKeybindings } from "@/contexts/keybindings-context";
+
+export function NavigationCommands() {
+  const { registerCommand, unregisterCommand } = useCommandRegistry();
+  const { bindings } = useKeybindings();
+  const router = useRouter();
+
+  const goToFleet = useCallback(() => router.push("/"), [router]);
+  const goToSettings = useCallback(() => router.push("/settings"), [router]);
+  const goToAlerts = useCallback(() => router.push("/alerts"), [router]);
+  const goToHistory = useCallback(() => router.push("/history"), [router]);
+
+  useEffect(() => {
+    registerCommand({
+      id: "nav-fleet",
+      label: "Go to Fleet",
+      icon: LayoutGrid,
+      category: "Navigation",
+      paletteHotkey: bindings["nav-fleet"]?.paletteHotkey ?? undefined,
+      keywords: ["home", "dashboard", "sessions"],
+      action: goToFleet,
+    });
+    registerCommand({
+      id: "nav-settings",
+      label: "Go to Settings",
+      icon: Settings,
+      category: "Navigation",
+      paletteHotkey: bindings["nav-settings"]?.paletteHotkey ?? undefined,
+      keywords: ["preferences", "config"],
+      action: goToSettings,
+    });
+    registerCommand({
+      id: "nav-alerts",
+      label: "Go to Alerts",
+      icon: Bell,
+      category: "Navigation",
+      paletteHotkey: bindings["nav-alerts"]?.paletteHotkey ?? undefined,
+      keywords: ["notifications"],
+      action: goToAlerts,
+    });
+    registerCommand({
+      id: "nav-history",
+      label: "Go to History",
+      icon: History,
+      category: "Navigation",
+      paletteHotkey: bindings["nav-history"]?.paletteHotkey ?? undefined,
+      keywords: ["past", "log"],
+      action: goToHistory,
+    });
+
+    return () => {
+      unregisterCommand("nav-fleet");
+      unregisterCommand("nav-settings");
+      unregisterCommand("nav-alerts");
+      unregisterCommand("nav-history");
+    };
+  }, [
+    registerCommand,
+    unregisterCommand,
+    bindings,
+    goToFleet,
+    goToSettings,
+    goToAlerts,
+    goToHistory,
+  ]);
+
+  return null;
+}

--- a/src/components/commands/session-commands.tsx
+++ b/src/components/commands/session-commands.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useCallback, useState } from "react";
+import { Plus, RefreshCw } from "lucide-react";
+import { useCommandRegistry } from "@/contexts/command-registry-context";
+import { useSessionsContext } from "@/contexts/sessions-context";
+import { NewSessionDialog } from "@/components/session/new-session-dialog";
+import { useKeybindings } from "@/contexts/keybindings-context";
+
+export function SessionCommands() {
+  const { registerCommand, unregisterCommand } = useCommandRegistry();
+  const { refetch } = useSessionsContext();
+  const { bindings } = useKeybindings();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const openNewSession = useCallback(() => setDialogOpen(true), []);
+  const refreshSessions = useCallback(() => refetch(), [refetch]);
+
+  useEffect(() => {
+    registerCommand({
+      id: "new-session",
+      label: "New Session",
+      icon: Plus,
+      category: "Session",
+      paletteHotkey: bindings["new-session"]?.paletteHotkey ?? undefined,
+      keywords: ["create", "spawn", "start"],
+      action: openNewSession,
+    });
+    registerCommand({
+      id: "refresh-sessions",
+      label: "Refresh Sessions",
+      icon: RefreshCw,
+      category: "Session",
+      paletteHotkey: bindings["refresh-sessions"]?.paletteHotkey ?? undefined,
+      keywords: ["reload", "update"],
+      action: refreshSessions,
+    });
+
+    return () => {
+      unregisterCommand("new-session");
+      unregisterCommand("refresh-sessions");
+    };
+  }, [registerCommand, unregisterCommand, bindings, openNewSession, refreshSessions]);
+
+  return (
+    <NewSessionDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+  );
+}

--- a/src/components/commands/view-commands.tsx
+++ b/src/components/commands/view-commands.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+import { PanelLeftClose } from "lucide-react";
+import { useCommandRegistry } from "@/contexts/command-registry-context";
+import { useSidebar } from "@/contexts/sidebar-context";
+import { useKeybindings } from "@/contexts/keybindings-context";
+
+export function ViewCommands() {
+  const { registerCommand, unregisterCommand } = useCommandRegistry();
+  const { toggleSidebar } = useSidebar();
+  const { bindings } = useKeybindings();
+
+  const toggle = useCallback(() => toggleSidebar(), [toggleSidebar]);
+
+  useEffect(() => {
+    registerCommand({
+      id: "toggle-sidebar",
+      label: "Toggle Sidebar",
+      icon: PanelLeftClose,
+      category: "View",
+      paletteHotkey: bindings["toggle-sidebar"]?.paletteHotkey ?? undefined,
+      globalShortcut: bindings["toggle-sidebar"]?.globalShortcut ?? undefined,
+      keywords: ["panel", "menu", "collapse", "expand"],
+      action: toggle,
+    });
+
+    return () => {
+      unregisterCommand("toggle-sidebar");
+    };
+  }, [registerCommand, unregisterCommand, bindings, toggle]);
+
+  return null;
+}

--- a/src/components/session/new-session-dialog.tsx
+++ b/src/components/session/new-session-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/sheet";
 import { Loader2, AlertCircle } from "lucide-react";
 import { useCreateSession } from "@/hooks/use-create-session";
+import type { ReactNode } from "react";
 
 type IsolationStrategy = "existing" | "worktree" | "clone";
 
@@ -42,17 +43,25 @@ const STRATEGY_DESCRIPTIONS: Record<IsolationStrategy, string> = {
 };
 
 interface NewSessionDialogProps {
-  trigger: React.ReactNode;
+  trigger?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function NewSessionDialog({ trigger }: NewSessionDialogProps) {
+export function NewSessionDialog({ trigger, open: controlledOpen, onOpenChange }: NewSessionDialogProps) {
   const router = useRouter();
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
   const [directory, setDirectory] = useState("");
   const [title, setTitle] = useState("");
   const [isolationStrategy, setIsolationStrategy] = useState<IsolationStrategy>("existing");
   const [branch, setBranch] = useState("");
   const { createSession, isLoading, error } = useCreateSession();
+
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (value: boolean) => {
+    setInternalOpen(value);
+    onOpenChange?.(value);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -79,7 +88,7 @@ export function NewSessionDialog({ trigger }: NewSessionDialogProps) {
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger asChild>{trigger}</SheetTrigger>
+      {trigger && <SheetTrigger asChild>{trigger}</SheetTrigger>}
       <SheetContent side="right" className="w-full max-w-sm">
         <SheetHeader>
           <SheetTitle>New Session</SheetTitle>

--- a/src/components/session/prompt-input.tsx
+++ b/src/components/session/prompt-input.tsx
@@ -17,6 +17,7 @@ interface PromptInputProps {
   agents?: AutocompleteAgent[];
   selectedAgent?: string | null;
   onAgentChange?: (agent: string | null) => void;
+  onFocusRequest?: (focus: () => void) => void;
 }
 
 export function PromptInput({
@@ -27,6 +28,7 @@ export function PromptInput({
   agents = [],
   selectedAgent = null,
   onAgentChange,
+  onFocusRequest,
 }: PromptInputProps) {
   const [value, setValue] = useState("");
   const [isSending, setIsSending] = useState(false);
@@ -41,6 +43,11 @@ export function PromptInput({
       inputRef.current?.focus();
     }
   }, [isDisabled]);
+
+  // Expose a focus callback via onFocusRequest
+  useEffect(() => {
+    onFocusRequest?.(() => inputRef.current?.focus());
+  }, [onFocusRequest]);
 
   const autocomplete = useAutocomplete({
     value,

--- a/src/components/settings/keybindings-tab.tsx
+++ b/src/components/settings/keybindings-tab.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  LayoutGrid,
+  Settings,
+  Bell,
+  History,
+  PanelLeftClose,
+  Plus,
+  RefreshCw,
+  MessageSquare,
+  RotateCcw,
+  type LucideIcon,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useKeybindings } from "@/contexts/keybindings-context";
+import { DEFAULT_KEYBINDINGS } from "@/lib/keybinding-types";
+import { formatShortcut, type ConflictResult } from "@/lib/keybinding-utils";
+import type { GlobalShortcut } from "@/lib/command-registry";
+
+// ─── Static command metadata ─────────────────────────────────────────────────
+
+interface CommandMeta {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  category: "Session" | "Navigation" | "View";
+}
+
+const COMMANDS: CommandMeta[] = [
+  { id: "new-session",      label: "New Session",       icon: Plus,          category: "Session" },
+  { id: "refresh-sessions", label: "Refresh Sessions",  icon: RefreshCw,     category: "Session" },
+  { id: "focus-prompt",     label: "Focus Prompt Input",icon: MessageSquare, category: "Session" },
+  { id: "nav-fleet",        label: "Go to Fleet",       icon: LayoutGrid,    category: "Navigation" },
+  { id: "nav-settings",     label: "Go to Settings",    icon: Settings,      category: "Navigation" },
+  { id: "nav-alerts",       label: "Go to Alerts",      icon: Bell,          category: "Navigation" },
+  { id: "nav-history",      label: "Go to History",     icon: History,       category: "Navigation" },
+  { id: "toggle-sidebar",   label: "Toggle Sidebar",    icon: PanelLeftClose,category: "View" },
+];
+
+const CATEGORY_ORDER: Array<"Session" | "Navigation" | "View"> = ["Session", "Navigation", "View"];
+
+// ─── KeyRecorder ─────────────────────────────────────────────────────────────
+
+interface KeyRecorderProps {
+  type: "palette" | "global";
+  onCapture: (key: string, shortcut?: GlobalShortcut) => void;
+  onCancel: () => void;
+}
+
+function KeyRecorder({ type, onCapture, onCancel }: KeyRecorderProps) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === "Escape") {
+        onCancel();
+        return;
+      }
+
+      if (type === "palette") {
+        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          onCapture(e.key.toLowerCase());
+        }
+      } else {
+        if ((e.metaKey || e.ctrlKey) && e.key.length === 1) {
+          const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+          onCapture(e.key.toLowerCase(), {
+            key: e.key.toLowerCase(),
+            platformModifier: (isMac && e.metaKey) || (!isMac && e.ctrlKey),
+          });
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [type, onCapture, onCancel]);
+
+  return (
+    <span className="text-xs animate-pulse text-amber-400">Press a key…</span>
+  );
+}
+
+// ─── BindingCell ─────────────────────────────────────────────────────────────
+
+interface BindingCellProps {
+  commandId: string;
+  type: "palette" | "global";
+  currentValue: string | null;
+  isRecording: boolean;
+  conflict: ConflictResult | null;
+  onStartRecording: () => void;
+  onCapture: (key: string, shortcut?: GlobalShortcut) => void;
+  onCancelRecording: () => void;
+}
+
+function BindingCell({
+  type,
+  currentValue,
+  isRecording,
+  conflict,
+  onStartRecording,
+  onCapture,
+  onCancelRecording,
+}: BindingCellProps) {
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+  if (isRecording) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="min-w-[80px] rounded border border-amber-400/60 px-2 py-1 text-center animate-pulse">
+          <KeyRecorder type={type} onCapture={onCapture} onCancel={onCancelRecording} />
+        </div>
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={onCancelRecording}
+          className="text-muted-foreground"
+        >
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={onStartRecording}
+        className="min-w-[80px] rounded border border-white/10 px-2 py-1 text-center text-xs hover:border-white/30 hover:bg-white/5 transition-colors cursor-pointer"
+        title="Click to rebind"
+      >
+        {currentValue ? (
+          <Badge variant="outline" className="font-mono text-xs">
+            {type === "global"
+              ? formatShortcut(
+                  typeof currentValue === "string"
+                    ? { key: currentValue }
+                    : currentValue,
+                  isMac
+                )
+              : currentValue.toUpperCase()}
+          </Badge>
+        ) : (
+          <span className="text-muted-foreground text-xs">—</span>
+        )}
+      </button>
+      {conflict && (
+        <p className="text-[10px] text-amber-400">
+          Conflicts with &quot;{conflict.conflictingCommandId}&quot;
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── KeybindingsTab ──────────────────────────────────────────────────────────
+
+type RecordingTarget = { commandId: string; type: "palette" | "global" } | null;
+
+export function KeybindingsTab() {
+  const { bindings, updateBinding, resetBinding, resetToDefaults, hasCustomBindings } =
+    useKeybindings();
+
+  const [recording, setRecording] = useState<RecordingTarget>(null);
+  const [conflicts, setConflicts] = useState<Record<string, ConflictResult>>({});
+
+  const startRecording = useCallback(
+    (commandId: string, type: "palette" | "global") => {
+      setRecording({ commandId, type });
+      // Clear any prior conflict for this command+type key
+      setConflicts((prev) => {
+        const next = { ...prev };
+        delete next[`${commandId}:${type}`];
+        return next;
+      });
+    },
+    []
+  );
+
+  const cancelRecording = useCallback(() => setRecording(null), []);
+
+  const handleCapture = useCallback(
+    (key: string, shortcut?: GlobalShortcut) => {
+      if (!recording) return;
+      const { commandId, type } = recording;
+
+      let conflict: ConflictResult | null = null;
+      if (type === "palette") {
+        conflict = updateBinding(commandId, { paletteHotkey: key });
+      } else if (shortcut) {
+        conflict = updateBinding(commandId, { globalShortcut: shortcut });
+      }
+
+      if (conflict) {
+        setConflicts((prev) => ({ ...prev, [`${commandId}:${type}`]: conflict! }));
+      } else {
+        setConflicts((prev) => {
+          const next = { ...prev };
+          delete next[`${commandId}:${type}`];
+          return next;
+        });
+      }
+
+      setRecording(null);
+    },
+    [recording, updateBinding]
+  );
+
+  const isDefaultBinding = useCallback(
+    (commandId: string) => {
+      const current = bindings[commandId];
+      const def = DEFAULT_KEYBINDINGS[commandId];
+      if (!current || !def) return true;
+      return (
+        current.paletteHotkey === def.paletteHotkey &&
+        current.globalShortcut?.key === def.globalShortcut?.key &&
+        !!current.globalShortcut?.platformModifier === !!def.globalShortcut?.platformModifier
+      );
+    },
+    [bindings]
+  );
+
+  const grouped = CATEGORY_ORDER.map((cat) => ({
+    category: cat,
+    commands: COMMANDS.filter((c) => c.category === cat),
+  }));
+
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold">Keybindings</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Customize keyboard shortcuts for commands.
+          </p>
+        </div>
+        {hasCustomBindings && (
+          <Button variant="outline" size="sm" onClick={resetToDefaults} className="gap-1.5">
+            <RotateCcw className="h-3.5 w-3.5" />
+            Reset All to Defaults
+          </Button>
+        )}
+      </div>
+
+      {grouped.map(({ category, commands }) => (
+        <Card key={category}>
+          <CardContent className="p-4 space-y-1">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+              {category}
+            </p>
+
+            {/* Table header */}
+            <div className="grid grid-cols-[1fr_100px_140px_auto] gap-3 items-center pb-2 border-b border-white/10">
+              <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Command</p>
+              <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Palette Key</p>
+              <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Global Shortcut</p>
+              <span />
+            </div>
+
+            {commands.map((cmd) => {
+              const binding = bindings[cmd.id] ?? DEFAULT_KEYBINDINGS[cmd.id];
+              const isDefault = isDefaultBinding(cmd.id);
+              const IconComponent = cmd.icon;
+
+              const isRecordingPalette =
+                recording?.commandId === cmd.id && recording.type === "palette";
+              const isRecordingGlobal =
+                recording?.commandId === cmd.id && recording.type === "global";
+
+              const paletteConflict = conflicts[`${cmd.id}:palette`] ?? null;
+              const globalConflict = conflicts[`${cmd.id}:global`] ?? null;
+
+              const globalShortcutDisplay = binding?.globalShortcut
+                ? formatShortcut(binding.globalShortcut, isMac)
+                : null;
+
+              return (
+                <div
+                  key={cmd.id}
+                  className="grid grid-cols-[1fr_100px_140px_auto] gap-3 items-center py-2 border-b border-white/5 last:border-0"
+                >
+                  {/* Label */}
+                  <div className="flex items-center gap-2">
+                    <IconComponent className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                    <span className="text-sm">{cmd.label}</span>
+                  </div>
+
+                  {/* Palette Hotkey */}
+                  <BindingCell
+                    commandId={cmd.id}
+                    type="palette"
+                    currentValue={binding?.paletteHotkey ?? null}
+                    isRecording={isRecordingPalette}
+                    conflict={paletteConflict}
+                    onStartRecording={() => startRecording(cmd.id, "palette")}
+                    onCapture={handleCapture}
+                    onCancelRecording={cancelRecording}
+                  />
+
+                  {/* Global Shortcut */}
+                  <BindingCell
+                    commandId={cmd.id}
+                    type="global"
+                    currentValue={globalShortcutDisplay}
+                    isRecording={isRecordingGlobal}
+                    conflict={globalConflict}
+                    onStartRecording={() => startRecording(cmd.id, "global")}
+                    onCapture={handleCapture}
+                    onCancelRecording={cancelRecording}
+                  />
+
+                  {/* Per-row reset */}
+                  <div className="w-8">
+                    {!isDefault && (
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={() => resetBinding(cmd.id)}
+                        title="Reset to default"
+                        className="text-muted-foreground hover:text-foreground"
+                      >
+                        <RotateCcw className="h-3 w-3" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/contexts/command-registry-context.tsx
+++ b/src/contexts/command-registry-context.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Command, CommandRegistryValue } from "@/lib/command-registry";
+
+const CommandRegistryContext = createContext<CommandRegistryValue | null>(null);
+
+interface CommandRegistryProviderProps {
+  children: ReactNode;
+}
+
+export function CommandRegistryProvider({ children }: CommandRegistryProviderProps) {
+  const commandsMapRef = useRef<Map<string, Command>>(new Map());
+  const [version, setVersion] = useState(0);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  const registerCommand = useCallback(
+    (command: Command) => {
+      commandsMapRef.current.set(command.id, command);
+      bump();
+    },
+    [bump]
+  );
+
+  const unregisterCommand = useCallback(
+    (id: string) => {
+      commandsMapRef.current.delete(id);
+      bump();
+    },
+    [bump]
+  );
+
+  // Global keydown dispatcher
+  useEffect(() => {
+    const isMac =
+      typeof navigator !== "undefined" &&
+      /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isTextInput =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.isContentEditable;
+
+      // Cmd+K / Ctrl+K toggles the palette — works even inside text inputs
+      if (e.key === "k" && (isMac ? e.metaKey : e.ctrlKey)) {
+        e.preventDefault();
+        setPaletteOpen((prev) => !prev);
+        return;
+      }
+
+      // Skip global shortcuts when focus is inside text fields
+      if (isTextInput) return;
+
+      // Dispatch global shortcuts
+      for (const command of commandsMapRef.current.values()) {
+        const gs = command.globalShortcut;
+        if (!gs) continue;
+        if (e.key !== gs.key) continue;
+
+        let modifierOk = false;
+        if (gs.platformModifier) {
+          modifierOk = isMac ? e.metaKey : e.ctrlKey;
+        } else if (gs.metaKey || gs.ctrlKey) {
+          if (gs.metaKey && e.metaKey) modifierOk = true;
+          if (gs.ctrlKey && e.ctrlKey) modifierOk = true;
+        } else {
+          modifierOk = true;
+        }
+
+        if (!modifierOk) continue;
+
+        e.preventDefault();
+        if (!command.disabled) {
+          command.action();
+        }
+        break;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Memoize sorted commands array — re-computes on version bump
+  const commands = useMemo(() => {
+    const categoryOrder: Record<string, number> = {
+      Session: 0,
+      Navigation: 1,
+      View: 2,
+    };
+    return Array.from(commandsMapRef.current.values()).sort((a, b) => {
+      const catDiff =
+        (categoryOrder[a.category] ?? 99) - (categoryOrder[b.category] ?? 99);
+      if (catDiff !== 0) return catDiff;
+      return a.label.localeCompare(b.label);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [version]);
+
+  const value: CommandRegistryValue = useMemo(
+    () => ({
+      commands,
+      paletteOpen,
+      setPaletteOpen,
+      registerCommand,
+      unregisterCommand,
+    }),
+    [commands, paletteOpen, registerCommand, unregisterCommand]
+  );
+
+  return (
+    <CommandRegistryContext.Provider value={value}>
+      {children}
+    </CommandRegistryContext.Provider>
+  );
+}
+
+export function useCommandRegistry(): CommandRegistryValue {
+  const ctx = useContext(CommandRegistryContext);
+  if (!ctx) {
+    throw new Error(
+      "useCommandRegistry must be used within a CommandRegistryProvider"
+    );
+  }
+  return ctx;
+}

--- a/src/contexts/keybindings-context.tsx
+++ b/src/contexts/keybindings-context.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
+import { usePersistedState } from "@/hooks/use-persisted-state";
+import {
+  DEFAULT_KEYBINDINGS,
+  type KeyBinding,
+  type KeyBindingsConfig,
+} from "@/lib/keybinding-types";
+import {
+  mergeWithDefaults,
+  detectPaletteConflict,
+  detectGlobalConflict,
+  type ConflictResult,
+} from "@/lib/keybinding-utils";
+
+interface KeybindingsContextValue {
+  bindings: KeyBindingsConfig;
+  updateBinding: (commandId: string, binding: Partial<KeyBinding>) => ConflictResult | null;
+  resetBinding: (commandId: string) => void;
+  resetToDefaults: () => void;
+  hasCustomBindings: boolean;
+}
+
+const KeybindingsContext = createContext<KeybindingsContextValue | null>(null);
+
+interface KeybindingsProviderProps {
+  children: ReactNode;
+}
+
+export function KeybindingsProvider({ children }: KeybindingsProviderProps) {
+  const [userOverrides, setUserOverrides] = usePersistedState<Partial<KeyBindingsConfig>>(
+    "weave:keybindings",
+    {}
+  );
+
+  const bindings = useMemo(
+    () => mergeWithDefaults(userOverrides, DEFAULT_KEYBINDINGS),
+    [userOverrides]
+  );
+
+  const updateBinding = useCallback(
+    (commandId: string, partial: Partial<KeyBinding>): ConflictResult | null => {
+      const current = bindings[commandId] ?? { paletteHotkey: null, globalShortcut: null };
+      const next: KeyBinding = { ...current, ...partial };
+
+      if (next.paletteHotkey !== null && next.paletteHotkey !== undefined) {
+        const conflict = detectPaletteConflict(commandId, next.paletteHotkey, bindings);
+        if (conflict) return conflict;
+      }
+
+      if (next.globalShortcut !== null && next.globalShortcut !== undefined) {
+        const conflict = detectGlobalConflict(commandId, next.globalShortcut, bindings);
+        if (conflict) return conflict;
+      }
+
+      setUserOverrides((prev) => ({ ...prev, [commandId]: next }));
+      return null;
+    },
+    [bindings, setUserOverrides]
+  );
+
+  const resetBinding = useCallback(
+    (commandId: string) => {
+      setUserOverrides((prev) => {
+        const next = { ...prev };
+        delete next[commandId];
+        return next;
+      });
+    },
+    [setUserOverrides]
+  );
+
+  const resetToDefaults = useCallback(() => {
+    setUserOverrides({});
+  }, [setUserOverrides]);
+
+  const hasCustomBindings = Object.keys(userOverrides).length > 0;
+
+  const value: KeybindingsContextValue = useMemo(
+    () => ({
+      bindings,
+      updateBinding,
+      resetBinding,
+      resetToDefaults,
+      hasCustomBindings,
+    }),
+    [bindings, updateBinding, resetBinding, resetToDefaults, hasCustomBindings]
+  );
+
+  return (
+    <KeybindingsContext.Provider value={value}>
+      {children}
+    </KeybindingsContext.Provider>
+  );
+}
+
+export function useKeybindings(): KeybindingsContextValue {
+  const ctx = useContext(KeybindingsContext);
+  if (!ctx) {
+    throw new Error("useKeybindings must be used within a KeybindingsProvider");
+  }
+  return ctx;
+}

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -8,7 +8,6 @@ import {
   type ReactNode,
 } from "react";
 import { usePersistedState } from "@/hooks/use-persisted-state";
-import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 
 const SIDEBAR_COLLAPSED_KEY = "weave:sidebar:collapsed";
 const SIDEBAR_WIDTH_KEY = "weave:sidebar:width";
@@ -50,9 +49,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
   const toggleSidebar = useCallback(() => {
     setCollapsed((prev) => !prev);
   }, [setCollapsed]);
-
-  // Global keyboard shortcut: Cmd+B on macOS, Ctrl+B elsewhere
-  useKeyboardShortcut("b", toggleSidebar, { platformModifier: true });
 
   return (
     <SidebarContext.Provider

--- a/src/lib/__tests__/keybinding-utils.test.ts
+++ b/src/lib/__tests__/keybinding-utils.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectPaletteConflict,
+  detectGlobalConflict,
+  formatShortcut,
+  mergeWithDefaults,
+} from "@/lib/keybinding-utils";
+import type { KeyBindingsConfig } from "@/lib/keybinding-types";
+import { DEFAULT_KEYBINDINGS } from "@/lib/keybinding-types";
+
+// ─── detectPaletteConflict ───────────────────────────────────────────────────
+
+describe("detectPaletteConflict", () => {
+  it("ReturnsNullWhenHotkeyIsUnique", () => {
+    const result = detectPaletteConflict("nav-fleet", "z", DEFAULT_KEYBINDINGS);
+    expect(result).toBeNull();
+  });
+
+  it("ReturnsConflictWhenHotkeyIsDuplicated", () => {
+    // "s" is bound to "nav-settings" by default
+    const result = detectPaletteConflict("nav-fleet", "s", DEFAULT_KEYBINDINGS);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("palette");
+    expect(result?.conflictingCommandId).toBe("nav-settings");
+    expect(result?.key).toBe("s");
+  });
+
+  it("SelfAssignmentIsNotAConflict", () => {
+    // "f" is the existing hotkey for "nav-fleet"; re-assigning same key should not conflict
+    const result = detectPaletteConflict("nav-fleet", "f", DEFAULT_KEYBINDINGS);
+    expect(result).toBeNull();
+  });
+
+  it("ReturnsNullForEmptyBindings", () => {
+    const bindings: KeyBindingsConfig = {};
+    const result = detectPaletteConflict("nav-fleet", "f", bindings);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── detectGlobalConflict ────────────────────────────────────────────────────
+
+describe("detectGlobalConflict", () => {
+  it("ReturnsNullWhenShortcutIsUnique", () => {
+    const result = detectGlobalConflict(
+      "new-command",
+      { key: "z", platformModifier: true },
+      DEFAULT_KEYBINDINGS
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ReturnsConflictOnMatchingKeyAndModifiers", () => {
+    // toggle-sidebar uses { key: "b", platformModifier: true }
+    const result = detectGlobalConflict(
+      "new-command",
+      { key: "b", platformModifier: true },
+      DEFAULT_KEYBINDINGS
+    );
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("global");
+    expect(result?.conflictingCommandId).toBe("toggle-sidebar");
+    expect(result?.key).toBe("b");
+  });
+
+  it("ReturnsNullWhenModifiersDiffer", () => {
+    // "b" without platformModifier does not conflict with toggle-sidebar
+    const result = detectGlobalConflict(
+      "new-command",
+      { key: "b", platformModifier: false },
+      DEFAULT_KEYBINDINGS
+    );
+    expect(result).toBeNull();
+  });
+
+  it("SelfAssignmentIsNotAConflict", () => {
+    const result = detectGlobalConflict(
+      "toggle-sidebar",
+      { key: "b", platformModifier: true },
+      DEFAULT_KEYBINDINGS
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ReturnsNullForEmptyBindings", () => {
+    const bindings: KeyBindingsConfig = {};
+    const result = detectGlobalConflict(
+      "toggle-sidebar",
+      { key: "b", platformModifier: true },
+      bindings
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ReturnsNullWhenNoGlobalShortcutsExist", () => {
+    const bindings: KeyBindingsConfig = {
+      "nav-fleet": { paletteHotkey: "f", globalShortcut: null },
+    };
+    const result = detectGlobalConflict(
+      "new-command",
+      { key: "f", platformModifier: true },
+      bindings
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ─── formatShortcut ──────────────────────────────────────────────────────────
+
+describe("formatShortcut", () => {
+  it("FormatsWithCommandSymbolOnMac", () => {
+    expect(formatShortcut({ key: "b", platformModifier: true }, true)).toBe("⌘B");
+  });
+
+  it("FormatsWithCtrlPlusOnNonMac", () => {
+    expect(formatShortcut({ key: "b", platformModifier: true }, false)).toBe("Ctrl+B");
+  });
+
+  it("FormatsMetaKeyAsCommandSymbol", () => {
+    expect(formatShortcut({ key: "k", metaKey: true }, true)).toBe("⌘K");
+    expect(formatShortcut({ key: "k", metaKey: true }, false)).toBe("⌘K");
+  });
+
+  it("FormatsCtrlKeyAsCtrlPlus", () => {
+    expect(formatShortcut({ key: "k", ctrlKey: true }, true)).toBe("Ctrl+K");
+    expect(formatShortcut({ key: "k", ctrlKey: true }, false)).toBe("Ctrl+K");
+  });
+
+  it("FormatsKeyWithNoModifier", () => {
+    expect(formatShortcut({ key: "x" }, true)).toBe("X");
+    expect(formatShortcut({ key: "x" }, false)).toBe("X");
+  });
+
+  it("UppercasesTheKey", () => {
+    expect(formatShortcut({ key: "enter", platformModifier: true }, true)).toBe("⌘ENTER");
+  });
+});
+
+// ─── mergeWithDefaults ───────────────────────────────────────────────────────
+
+describe("mergeWithDefaults", () => {
+  it("ReturnsCopyOfDefaultsWhenNoUserOverrides", () => {
+    const result = mergeWithDefaults({}, DEFAULT_KEYBINDINGS);
+    expect(result).toEqual(DEFAULT_KEYBINDINGS);
+    // Must be a copy, not the same reference
+    expect(result).not.toBe(DEFAULT_KEYBINDINGS);
+  });
+
+  it("UserOverridesWinOverDefaults", () => {
+    const userBindings: Partial<KeyBindingsConfig> = {
+      "nav-fleet": { paletteHotkey: "g", globalShortcut: null },
+    };
+    const result = mergeWithDefaults(userBindings, DEFAULT_KEYBINDINGS);
+    expect(result["nav-fleet"].paletteHotkey).toBe("g");
+  });
+
+  it("GapsFillWithDefaultBindings", () => {
+    const userBindings: Partial<KeyBindingsConfig> = {
+      "nav-fleet": { paletteHotkey: "g", globalShortcut: null },
+    };
+    const result = mergeWithDefaults(userBindings, DEFAULT_KEYBINDINGS);
+    // Other commands should retain defaults
+    expect(result["nav-settings"]).toEqual(DEFAULT_KEYBINDINGS["nav-settings"]);
+    expect(result["toggle-sidebar"]).toEqual(DEFAULT_KEYBINDINGS["toggle-sidebar"]);
+  });
+
+  it("UserCanSetHotkeyToNull", () => {
+    const userBindings: Partial<KeyBindingsConfig> = {
+      "nav-fleet": { paletteHotkey: null, globalShortcut: null },
+    };
+    const result = mergeWithDefaults(userBindings, DEFAULT_KEYBINDINGS);
+    expect(result["nav-fleet"].paletteHotkey).toBeNull();
+  });
+
+  it("FalsyUserBindingValueIsSkipped", () => {
+    // Passing undefined for a key (Partial allows it) should not override default
+    const userBindings: Partial<KeyBindingsConfig> = {
+      "nav-fleet": undefined,
+    };
+    const result = mergeWithDefaults(userBindings, DEFAULT_KEYBINDINGS);
+    expect(result["nav-fleet"]).toEqual(DEFAULT_KEYBINDINGS["nav-fleet"]);
+  });
+});

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -1,0 +1,31 @@
+import type { LucideIcon } from "lucide-react";
+
+export type CommandCategory = "Session" | "Navigation" | "View";
+
+export interface GlobalShortcut {
+  key: string;
+  platformModifier?: boolean;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+}
+
+export interface Command {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: LucideIcon;
+  category: CommandCategory;
+  paletteHotkey?: string;
+  globalShortcut?: GlobalShortcut;
+  action: () => void;
+  keywords?: string[];
+  disabled?: boolean;
+}
+
+export interface CommandRegistryValue {
+  commands: Command[];
+  paletteOpen: boolean;
+  setPaletteOpen: (open: boolean) => void;
+  registerCommand: (command: Command) => void;
+  unregisterCommand: (id: string) => void;
+}

--- a/src/lib/keybinding-types.ts
+++ b/src/lib/keybinding-types.ts
@@ -1,0 +1,19 @@
+import type { GlobalShortcut } from "@/lib/command-registry";
+
+export interface KeyBinding {
+  paletteHotkey: string | null;
+  globalShortcut: GlobalShortcut | null;
+}
+
+export type KeyBindingsConfig = Record<string, KeyBinding>;
+
+export const DEFAULT_KEYBINDINGS: KeyBindingsConfig = {
+  "nav-fleet":        { paletteHotkey: "f", globalShortcut: null },
+  "nav-settings":     { paletteHotkey: "s", globalShortcut: null },
+  "nav-alerts":       { paletteHotkey: "a", globalShortcut: null },
+  "nav-history":      { paletteHotkey: "h", globalShortcut: null },
+  "toggle-sidebar":   { paletteHotkey: "b", globalShortcut: { key: "b", platformModifier: true } },
+  "new-session":      { paletteHotkey: "n", globalShortcut: null },
+  "refresh-sessions": { paletteHotkey: "r", globalShortcut: null },
+  "focus-prompt":     { paletteHotkey: "/", globalShortcut: null },
+};

--- a/src/lib/keybinding-utils.ts
+++ b/src/lib/keybinding-utils.ts
@@ -1,0 +1,68 @@
+import type { GlobalShortcut } from "@/lib/command-registry";
+import type { KeyBindingsConfig } from "@/lib/keybinding-types";
+
+export interface ConflictResult {
+  type: "palette" | "global";
+  conflictingCommandId: string;
+  key: string;
+}
+
+export function detectPaletteConflict(
+  commandId: string,
+  newHotkey: string,
+  bindings: KeyBindingsConfig
+): ConflictResult | null {
+  for (const [id, binding] of Object.entries(bindings)) {
+    if (id === commandId) continue;
+    if (binding.paletteHotkey === newHotkey) {
+      return { type: "palette", conflictingCommandId: id, key: newHotkey };
+    }
+  }
+  return null;
+}
+
+export function detectGlobalConflict(
+  commandId: string,
+  newShortcut: GlobalShortcut,
+  bindings: KeyBindingsConfig
+): ConflictResult | null {
+  for (const [id, binding] of Object.entries(bindings)) {
+    if (id === commandId) continue;
+    const gs = binding.globalShortcut;
+    if (!gs) continue;
+    if (
+      gs.key === newShortcut.key &&
+      !!gs.platformModifier === !!newShortcut.platformModifier &&
+      !!gs.metaKey === !!newShortcut.metaKey &&
+      !!gs.ctrlKey === !!newShortcut.ctrlKey
+    ) {
+      return { type: "global", conflictingCommandId: id, key: newShortcut.key };
+    }
+  }
+  return null;
+}
+
+export function formatShortcut(shortcut: GlobalShortcut, isMac: boolean): string {
+  let modifier = "";
+  if (shortcut.platformModifier) {
+    modifier = isMac ? "⌘" : "Ctrl+";
+  } else if (shortcut.metaKey) {
+    modifier = "⌘";
+  } else if (shortcut.ctrlKey) {
+    modifier = "Ctrl+";
+  }
+  return `${modifier}${shortcut.key.toUpperCase()}`;
+}
+
+export function mergeWithDefaults(
+  userBindings: Partial<KeyBindingsConfig>,
+  defaults: KeyBindingsConfig
+): KeyBindingsConfig {
+  const result = { ...defaults };
+  for (const [id, binding] of Object.entries(userBindings)) {
+    if (binding) {
+      result[id] = binding;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- Implements a full `Cmd+K` command palette with central command registry, fuzzy search, grouped commands, hotkey badges, and palette hotkey interception
- Adds 8 default commands (navigation, view, session, context-sensitive) with `Cmd+B` sidebar toggle migrated from standalone hook into the registry
- Delivers user-configurable keybindings with a Settings tab, localStorage persistence, conflict detection, recording mode, and "Reset to Defaults"

Closes #30

## Details

### Phase 1 — Command Palette & Registry
| File | Action | Purpose |
|------|--------|---------|
| `src/lib/command-registry.ts` | Create | Command/GlobalShortcut/CommandRegistryValue types |
| `src/contexts/command-registry-context.tsx` | Create | Registry provider with Map storage, global shortcut dispatcher, Cmd+K toggle |
| `src/components/command-palette.tsx` | Create | Palette UI with cmdk, grouped by category, hotkey interception, footer hints |
| `src/components/commands/navigation-commands.tsx` | Create | Registers Fleet/Settings/Alerts/History commands |
| `src/components/commands/view-commands.tsx` | Create | Registers Toggle Sidebar with globalShortcut |
| `src/components/commands/session-commands.tsx` | Create | Registers New Session + Refresh Sessions, renders controlled NewSessionDialog |
| `src/app/client-layout.tsx` | Modify | Provider nesting + mount headless components + CommandPalette |
| `src/contexts/sidebar-context.tsx` | Modify | Remove standalone useKeyboardShortcut (migrated to registry) |
| `src/components/session/new-session-dialog.tsx` | Modify | Accept controlled open/onOpenChange props |
| `src/components/session/prompt-input.tsx` | Modify | onFocusRequest callback for external focus |
| `src/app/sessions/[id]/page.tsx` | Modify | Register context-sensitive "Focus Prompt Input" command |

### Phase 2 — User Configuration
| File | Action | Purpose |
|------|--------|---------|
| `src/lib/keybinding-types.ts` | Create | KeyBinding types + DEFAULT_KEYBINDINGS map |
| `src/lib/keybinding-utils.ts` | Create | Conflict detection, shortcut formatting, merge utilities |
| `src/lib/__tests__/keybinding-utils.test.ts` | Create | 21 unit tests for all utility functions |
| `src/contexts/keybindings-context.tsx` | Create | Persistence layer via usePersistedState + localStorage |
| `src/components/settings/keybindings-tab.tsx` | Create | Settings tab with KeyRecorder, per-row reset, conflict warnings |
| `src/app/settings/page.tsx` | Modify | Add Keybindings tab |

## Verification
- ✅ `npm run typecheck` — clean
- ✅ `npm run test` — 548/548 pass (incl. 21 new keybinding-utils tests)
- ⚠️ `npm run build` — pre-existing `_global-error` SSG issue (Next.js 16 framework bug, unrelated)