### PR TITLE
fix: session indicator stays inactive after lazy instance recovery

### DIFF
--- a/src/lib/server/__tests__/opencode-client.test.ts
+++ b/src/lib/server/__tests__/opencode-client.test.ts
@@ -18,6 +18,7 @@ const {
   mockGetSessionByOpencodeId,
   mockGetDbInstance,
   mockUpdateSessionInstanceId,
+  mockUpdateSessionStatus,
 } = vi.hoisted(() => ({
   mockGetInstanceFromPM: vi.fn(),
   mockSpawnInstance: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockGetSessionByOpencodeId: vi.fn(),
   mockGetDbInstance: vi.fn(),
   mockUpdateSessionInstanceId: vi.fn(),
+  mockUpdateSessionStatus: vi.fn(),
 }));
 
 vi.mock("@/lib/server/process-manager", () => ({
@@ -37,6 +39,7 @@ vi.mock("@/lib/server/db-repository", () => ({
   getSessionByOpencodeId: mockGetSessionByOpencodeId,
   getInstance: mockGetDbInstance,
   updateSessionInstanceId: mockUpdateSessionInstanceId,
+  updateSessionStatus: mockUpdateSessionStatus,
 }));
 
 vi.mock("@/lib/server/logger", () => ({
@@ -217,6 +220,72 @@ describe("ensureInstanceForSession", () => {
     });
 
     // Should NOT throw — DB update failure is non-fatal
+    const result = await ensureInstanceForSession("inst-old", "db-sess-1");
+
+    expect(result.instance).toBe(newInst);
+    expect(result.client).toBe(newInst.client);
+  });
+
+  it.each(["stopped", "completed", "disconnected", "error"] as const)(
+    "SlowPath_TransitionsTerminalStatus_%s_ToIdle",
+    async (terminalStatus) => {
+      mockGetInstanceFromPM.mockReturnValue(undefined);
+
+      const dbSess = makeDbSession({ instance_id: "inst-old", status: terminalStatus });
+      mockGetDbSession.mockReturnValue(dbSess);
+
+      const newInst = makeManagedInstance("inst-new");
+      mockSpawnInstance.mockResolvedValue(newInst);
+
+      await ensureInstanceForSession("inst-old", "db-sess-1");
+
+      expect(mockUpdateSessionStatus).toHaveBeenCalledWith("db-sess-1", "idle");
+    }
+  );
+
+  it("SlowPath_DoesNotTransitionActiveSessionToIdle", async () => {
+    mockGetInstanceFromPM.mockReturnValue(undefined);
+
+    const dbSess = makeDbSession({ instance_id: "inst-old", status: "active" });
+    mockGetDbSession.mockReturnValue(dbSess);
+
+    const newInst = makeManagedInstance("inst-new");
+    mockSpawnInstance.mockResolvedValue(newInst);
+
+    await ensureInstanceForSession("inst-old", "db-sess-1");
+
+    expect(mockUpdateSessionStatus).not.toHaveBeenCalled();
+  });
+
+  it("SlowPath_DoesNotTransitionIdleSessionToIdle", async () => {
+    mockGetInstanceFromPM.mockReturnValue(undefined);
+
+    const dbSess = makeDbSession({ instance_id: "inst-old", status: "idle" });
+    mockGetDbSession.mockReturnValue(dbSess);
+
+    const newInst = makeManagedInstance("inst-new");
+    mockSpawnInstance.mockResolvedValue(newInst);
+
+    await ensureInstanceForSession("inst-old", "db-sess-1");
+
+    expect(mockUpdateSessionStatus).not.toHaveBeenCalled();
+  });
+
+  it("SlowPath_StatusTransitionFailureIsNonFatal", async () => {
+    mockGetInstanceFromPM.mockReturnValue(undefined);
+
+    const dbSess = makeDbSession({ instance_id: "inst-old", status: "stopped" });
+    mockGetDbSession.mockReturnValue(dbSess);
+
+    const newInst = makeManagedInstance("inst-new");
+    mockSpawnInstance.mockResolvedValue(newInst);
+
+    // Status update fails
+    mockUpdateSessionStatus.mockImplementation(() => {
+      throw new Error("DB write error");
+    });
+
+    // Should NOT throw — status transition failure is non-fatal
     const result = await ensureInstanceForSession("inst-old", "db-sess-1");
 
     expect(result.instance).toBe(newInst);

--- a/src/lib/server/opencode-client.ts
+++ b/src/lib/server/opencode-client.ts
@@ -10,6 +10,7 @@ import {
   getSessionByOpencodeId,
   getInstance as getDbInstance,
   updateSessionInstanceId,
+  updateSessionStatus,
 } from "./db-repository";
 import { log } from "./logger";
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
@@ -51,8 +52,10 @@ export function getClientForInstance(instanceId: string): OpencodeClient {
  *  3. Update the session's instance_id FK so subsequent requests take the fast path.
  *  4. Return { instance, client }.
  *
- * This does NOT change the session's status or stopped_at — that is the
- * responsibility of the session-status-watcher or user-initiated resume.
+ * When the session was in a terminal state (stopped, completed, disconnected,
+ * error), this also transitions it to "idle" so the sidebar immediately reflects
+ * a running session and the session-status-watcher can process subsequent events
+ * (the watcher ignores sessions with terminal DB status).
  *
  * Throws if the session is not found in DB or if spawning fails.
  */
@@ -93,6 +96,26 @@ export async function ensureInstanceForSession(
       log.warn("opencode-client", "Failed to update session instance_id in DB", {
         sessionId: dbSession.id,
         newInstanceId: newInstance.id,
+        err,
+      });
+    }
+  }
+
+  // Transition sessions out of terminal status so the sidebar reflects the
+  // running instance and the session-status-watcher can process subsequent
+  // busy/idle events (the watcher skips sessions with terminal DB status).
+  const TERMINAL_STATUSES = ["stopped", "completed", "disconnected", "error"];
+  if (TERMINAL_STATUSES.includes(dbSession.status)) {
+    try {
+      updateSessionStatus(dbSession.id, "idle");
+      log.info("opencode-client", "Transitioned session from terminal to idle after lazy recovery", {
+        sessionId: dbSession.id,
+        previousStatus: dbSession.status,
+      });
+    } catch (err) {
+      log.warn("opencode-client", "Failed to transition session status after lazy recovery", {
+        sessionId: dbSession.id,
+        previousStatus: dbSession.status,
         err,
       });
     }


### PR DESCRIPTION
## Summary

- Fixes a bug where clicking an inactive session reactivated it (instance spawned, SSE connected) but the sidebar indicator remained grey/inactive and the session was filtered out by the "hide inactive" toggle.
- Root cause: `ensureInstanceForSession()` only updated the `instance_id` FK during lazy recovery, leaving the session's DB status as terminal (`stopped`/`completed`/`disconnected`/`error`). This meant `GET /api/sessions` returned the terminal status (grey dot) and the `session-status-watcher` ignored subsequent busy/idle events (it skips terminal sessions).
- Fix: after lazy instance recovery, `ensureInstanceForSession()` now transitions terminal sessions to `idle` so the sidebar immediately reflects a running session and the watcher can process subsequent events.

## Changes

- **`src/lib/server/opencode-client.ts`** — After updating the instance FK, transition sessions with terminal DB status to `idle` via `updateSessionStatus()`. Non-fatal if the DB write fails.
- **`src/lib/server/__tests__/opencode-client.test.ts`** — 7 new tests: parameterized terminal→idle transitions for all 4 terminal statuses, 2 negative tests (active/idle not redundantly transitioned), and 1 error-resilience test.
