### PR TITLE
Clean up right sidebar: remove redundant sections

### DIFF
--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -16,7 +16,7 @@ import { useDiffs } from "@/hooks/use-diffs";
 import { apiFetch } from "@/lib/api-client";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { FolderOpen, GitBranch, GitCompare, GitFork, Server, Clock, Hash, Square, RotateCcw, Trash2, MessageSquare, OctagonX, AlertTriangle, RefreshCw, ArrowLeft, ChevronRight, ArrowUpToLine, ArrowDownToLine, ListTodo, Eraser, ScrollText, PanelRight, MoreHorizontal, FileCode } from "lucide-react";
+import { FolderOpen, GitBranch, GitCompare, GitFork, Server, Clock, Hash, Square, RotateCcw, Trash2, MessageSquare, OctagonX, ArrowLeft, ChevronRight, ArrowUpToLine, ArrowDownToLine, ListTodo, Eraser, ScrollText, PanelRight, MoreHorizontal, FileCode } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useFoldableScreen } from "@/hooks/use-foldable-screen";
@@ -521,19 +521,6 @@ export default function SessionDetailPage() {
     ? agents.find((a) => a.name === activeAgentName)
     : null;
 
-  // Compute participating agents with message counts for sidebar
-  const participatingAgents = (() => {
-    const counts = new Map<string, number>();
-    for (const m of messages) {
-      if (m.agent) counts.set(m.agent, (counts.get(m.agent) ?? 0) + 1);
-    }
-    return Array.from(counts.entries()).map(([name, count]) => ({
-      name,
-      count,
-      meta: agents.find((a) => a.name === name),
-    }));
-  })();
-
   const handleSend = useCallback(
     async (text: string, agent?: string, model?: SelectedModel, attachments?: ImageAttachment[]) => {
       await sendPrompt(sessionId, instanceId, text, agent, model ?? undefined, attachments);
@@ -994,77 +981,6 @@ export default function SessionDetailPage() {
                 </>
               )}
 
-              {/* Active Agents */}
-              {participatingAgents.length > 0 && (
-                <>
-                  <Separator />
-                  <div className="space-y-2">
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Agents</p>
-                    {participatingAgents.map(({ name, count, meta }) => (
-                      <div key={name} className="flex items-center gap-1.5">
-                        <span
-                          className="h-1.5 w-1.5 rounded-full flex-shrink-0"
-                          style={{ backgroundColor: meta?.color ?? "var(--muted-foreground)" }}
-                        />
-                        <span className="text-xs flex-1">
-                          {name.charAt(0).toUpperCase() + name.slice(1)}
-                        </span>
-                        <span className="text-[10px] text-muted-foreground">
-                          {count} msg{count !== 1 ? "s" : ""}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </>
-              )}
-
-              <Separator />
-
-              {/* Connection status */}
-              <div className="space-y-1">
-                <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Connection</p>
-                <div className="flex items-center gap-1.5">
-                  {status === "error" ? (
-                    <AlertTriangle className="h-3 w-3 text-red-500 shrink-0" />
-                  ) : status === "disconnected" || status === "abandoned" ? (
-                    <AlertTriangle className="h-3 w-3 text-amber-600 dark:text-amber-400 shrink-0" />
-                  ) : (
-                    <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${
-                      status === "connected" ? "bg-green-500" :
-                      status === "connecting" ? "bg-amber-500 animate-pulse" :
-                      status === "recovering" ? "bg-blue-500 animate-pulse" :
-                      "bg-red-500"
-                    }`} />
-                  )}
-                  <p className={`text-xs ${
-                    status === "error" ? "text-red-500 font-medium" :
-                    status === "disconnected" || status === "abandoned" ? "text-amber-600 dark:text-amber-400" :
-                    ""
-                  }`}>
-                    {status === "error" ? "Error" :
-                     status === "abandoned"
-                       ? "Instance unreachable"
-                       : status === "disconnected"
-                       ? `Disconnected${reconnectAttempt > 0 ? ` (retry ${reconnectAttempt})` : ""}`
-                       : status === "recovering" ? "Recovering…"
-                       : status === "connecting" ? "Connecting…"
-                       : "Connected"}
-                  </p>
-                </div>
-                {(status === "disconnected" || status === "abandoned") && (
-                  <button
-                    onClick={reconnect}
-                    className="mt-1 inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium bg-amber-500/10 hover:bg-amber-500/20 text-amber-600 dark:text-amber-400 transition-colors"
-                  >
-                    <RefreshCw className="h-2.5 w-2.5" />
-                    Reconnect
-                  </button>
-                )}
-                {status === "error" && error && (
-                  <p className="text-[10px] text-red-600/70 dark:text-red-400/70 break-words mt-0.5">{error}</p>
-                )}
-              </div>
-
               {/* Todos — shown when agent has used todowrite */}
               {latestTodos && latestTodos.length > 0 && (
                 <>
@@ -1163,77 +1079,6 @@ export default function SessionDetailPage() {
                   </div>
                 </>
               )}
-
-              {/* Active Agents */}
-              {participatingAgents.length > 0 && (
-                <>
-                  <Separator />
-                  <div className="space-y-2">
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Agents</p>
-                    {participatingAgents.map(({ name, count, meta }) => (
-                      <div key={name} className="flex items-center gap-1.5">
-                        <span
-                          className="h-1.5 w-1.5 rounded-full flex-shrink-0"
-                          style={{ backgroundColor: meta?.color ?? "var(--muted-foreground)" }}
-                        />
-                        <span className="text-xs flex-1">
-                          {name.charAt(0).toUpperCase() + name.slice(1)}
-                        </span>
-                        <span className="text-[10px] text-muted-foreground">
-                          {count} msg{count !== 1 ? "s" : ""}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </>
-              )}
-
-              <Separator />
-
-              {/* Connection status */}
-              <div className="space-y-1">
-                <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Connection</p>
-                <div className="flex items-center gap-1.5">
-                  {status === "error" ? (
-                    <AlertTriangle className="h-3 w-3 text-red-500 shrink-0" />
-                  ) : status === "disconnected" || status === "abandoned" ? (
-                    <AlertTriangle className="h-3 w-3 text-amber-600 dark:text-amber-400 shrink-0" />
-                  ) : (
-                    <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${
-                      status === "connected" ? "bg-green-500" :
-                      status === "connecting" ? "bg-amber-500 animate-pulse" :
-                      status === "recovering" ? "bg-blue-500 animate-pulse" :
-                      "bg-red-500"
-                    }`} />
-                  )}
-                  <p className={`text-xs ${
-                    status === "error" ? "text-red-500 font-medium" :
-                    status === "disconnected" || status === "abandoned" ? "text-amber-600 dark:text-amber-400" :
-                    ""
-                  }`}>
-                    {status === "error" ? "Error" :
-                     status === "abandoned"
-                       ? "Instance unreachable"
-                       : status === "disconnected"
-                       ? `Disconnected${reconnectAttempt > 0 ? ` (retry ${reconnectAttempt})` : ""}`
-                       : status === "recovering" ? "Recovering…"
-                       : status === "connecting" ? "Connecting…"
-                       : "Connected"}
-                  </p>
-                </div>
-                {(status === "disconnected" || status === "abandoned") && (
-                  <button
-                    onClick={reconnect}
-                    className="mt-1 inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium bg-amber-500/10 hover:bg-amber-500/20 text-amber-600 dark:text-amber-400 transition-colors"
-                  >
-                    <RefreshCw className="h-2.5 w-2.5" />
-                    Reconnect
-                  </button>
-                )}
-                {status === "error" && error && (
-                  <p className="text-[10px] text-red-600/70 dark:text-red-400/70 break-words mt-0.5">{error}</p>
-                )}
-              </div>
 
               {/* Todos — shown when agent has used todowrite */}
               {latestTodos && latestTodos.length > 0 && (

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -16,7 +16,7 @@ import { useDiffs } from "@/hooks/use-diffs";
 import { apiFetch } from "@/lib/api-client";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { FolderOpen, GitBranch, GitCompare, GitFork, Server, Clock, Hash, Square, RotateCcw, Trash2, MessageSquare, OctagonX, ArrowLeft, ChevronRight, ArrowUpToLine, ArrowDownToLine, ListTodo, Eraser, ScrollText, PanelRight, MoreHorizontal, FileCode } from "lucide-react";
+import { GitCompare, GitFork, Server, Hash, Square, RotateCcw, Trash2, MessageSquare, OctagonX, ArrowLeft, ChevronRight, ArrowUpToLine, ArrowDownToLine, ListTodo, Eraser, ScrollText, PanelRight, MoreHorizontal, FileCode } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useFoldableScreen } from "@/hooks/use-foldable-screen";
@@ -599,6 +599,7 @@ export default function SessionDetailPage() {
     <div className="flex flex-col h-full">
       <Header
         title={contextTitle || metadata.title || sessionId.slice(0, 12)}
+        subtitle={metadata.workspaceDirectory ?? undefined}
         actions={
           <div className="flex items-center gap-1 sm:gap-2">
             <span
@@ -915,41 +916,6 @@ export default function SessionDetailPage() {
                 Session Info
               </p>
 
-              {/* Workspace */}
-              {metadata.workspaceDirectory && (
-                <div className="space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <FolderOpen className="h-3 w-3 text-muted-foreground" />
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Workspace</p>
-                  </div>
-                  <p className="text-xs font-mono break-all">{metadata.workspaceDirectory}</p>
-                </div>
-              )}
-
-              {/* Isolation Strategy */}
-              {metadata.isolationStrategy && (
-                <div className="space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <GitBranch className="h-3 w-3 text-muted-foreground" />
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Isolation</p>
-                  </div>
-                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                    {metadata.isolationStrategy}
-                  </Badge>
-                </div>
-              )}
-
-              {/* Created At */}
-              {metadata.createdAt && (
-                <div className="space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <Clock className="h-3 w-3 text-muted-foreground" />
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Created</p>
-                  </div>
-                  <p className="text-xs">{new Date(metadata.createdAt).toLocaleString()}</p>
-                </div>
-              )}
-
               <Separator />
 
               {/* Tokens & Cost */}
@@ -1014,41 +980,6 @@ export default function SessionDetailPage() {
           </SheetHeader>
           <ScrollArea className="h-[calc(100%-3rem)]">
             <div className="px-4 pb-4 space-y-4">
-              {/* Workspace */}
-              {metadata.workspaceDirectory && (
-                <div className="space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <FolderOpen className="h-3 w-3 text-muted-foreground" />
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Workspace</p>
-                  </div>
-                  <p className="text-xs font-mono break-all">{metadata.workspaceDirectory}</p>
-                </div>
-              )}
-
-              {/* Isolation Strategy */}
-              {metadata.isolationStrategy && (
-                <div className="space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <GitBranch className="h-3 w-3 text-muted-foreground" />
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Isolation</p>
-                  </div>
-                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                    {metadata.isolationStrategy}
-                  </Badge>
-                </div>
-              )}
-
-              {/* Created At */}
-              {metadata.createdAt && (
-                <div className="space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <Clock className="h-3 w-3 text-muted-foreground" />
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Created</p>
-                  </div>
-                  <p className="text-xs">{new Date(metadata.createdAt).toLocaleString()}</p>
-                </div>
-              )}
-
               <Separator />
 
               {/* Tokens & Cost */}


### PR DESCRIPTION
## Summary

- **Remove Agents and Connection sections** from the right sidebar (desktop + mobile) — these duplicate info already visible in the header bar
- **Move workspace directory** to display as subtitle text under the session title in the header, removing it from the sidebar
- **Remove Created timestamp** and **Isolation strategy** sections from the sidebar to reduce clutter
- Clean up unused imports and dead code (`participatingAgents` computation)

The right sidebar now shows: Session Info heading → Tokens & Cost → Changes → Todos → GitHub Links.

Net result: **-227 lines**, leaner sidebar focused on actionable information.