### PR TITLE
fix: sidebar panel not expanding when clicking a different icon while collapsed

### DIFF
--- a/src/components/layout/sidebar-icon-rail.tsx
+++ b/src/components/layout/sidebar-icon-rail.tsx
@@ -257,13 +257,9 @@ export function SidebarIconRail() {
   const handleSwitch = useCallback(
     (view: SidebarView) => {
       if (isCollapsed && viewHasPanel(view)) {
-        if (activeView === view) {
-          // Re-clicking the active icon while collapsed → expand
-          setCollapsed(false);
-        } else {
-          // Switching to a different panel icon while collapsed → just switch view, stay collapsed
-          setActiveView(view);
-        }
+        // Clicking any panel icon while collapsed → switch view and expand
+        setActiveView(view);
+        setCollapsed(false);
         return;
       }
       setActiveView(nextViewForSwitch(activeView, view));


### PR DESCRIPTION
## Summary

- **Bug:** When the left sidebar panel was collapsed and a user clicked a *different* panel icon (e.g. Fleet → GitHub), the icon highlight changed but the panel stayed closed. Only re-clicking the *same* icon would expand it.
- **Fix:** Simplified the `handleSwitch` collapsed branch in `sidebar-icon-rail.tsx` so clicking any panel icon while collapsed both switches the view and expands the panel.

## Changes

- `src/components/layout/sidebar-icon-rail.tsx` — Removed the two-case split (same icon vs different icon) when `isCollapsed` is true. Now any panel icon click while collapsed calls both `setActiveView(view)` and `setCollapsed(false)`.
