### PR TITLE
fix: sidebar expand button not opening panel when on welcome view

### DIFF
--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -147,8 +147,15 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
       setMobileDrawerOpen((open) => !open);
       return;
     }
+    // When expanding from a view that has no panel (e.g. welcome),
+    // restore the last panel view so the panel actually appears.
+    if (isCollapsed && !viewHasPanel(activeView)) {
+      setActiveViewState(lastPanelViewRef.current);
+      setIsCollapsed(false);
+      return;
+    }
     setIsCollapsed((prev) => !prev);
-  }, [isMobileNav, setIsCollapsed, setMobileDrawerOpen]);
+  }, [isMobileNav, isCollapsed, activeView, setActiveViewState, setIsCollapsed, setMobileDrawerOpen]);
 
   const toggleSidebar = useCallback(() => {
     if (isMobileNav) {


### PR DESCRIPTION
## Summary

- **Bug:** The sidebar expand/collapse toggle button (PanelLeft icon) did nothing when `activeView` was `welcome` — because `panelOpen` is derived as `viewHasPanel(activeView) && !isCollapsed`, and `welcome` has no panel.
- **Fix:** Updated `toggleCollapse` in `sidebar-context.tsx` to restore the last panel view before expanding when the current view has no panel — matching the existing `toggleSidebar` (Cmd+B) behavior.
- Single-file change in `src/contexts/sidebar-context.tsx`.