### PR TITLE
fix: sidebar toggle button not opening panel when on non-panel view

### DIFF
--- a/src/components/layout/sidebar-icon-rail.tsx
+++ b/src/components/layout/sidebar-icon-rail.tsx
@@ -330,19 +330,19 @@ export function SidebarIconRail() {
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                aria-label={panelOpen ? "Collapse sidebar" : "Expand sidebar"}
                 onClick={toggleCollapse}
                 className="flex h-8 w-full items-center justify-center rounded-sm text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground transition-colors"
               >
-                {isCollapsed ? (
-                  <PanelLeft className="h-4 w-4 shrink-0" />
-                ) : (
+                {panelOpen ? (
                   <PanelLeftClose className="h-4 w-4 shrink-0" />
+                ) : (
+                  <PanelLeft className="h-4 w-4 shrink-0" />
                 )}
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">
-              {isCollapsed ? "Expand sidebar (⌘B)" : "Collapse sidebar (⌘B)"}
+              {panelOpen ? "Collapse sidebar (⌘B)" : "Expand sidebar (⌘B)"}
             </TooltipContent>
           </Tooltip>
         </div>

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -147,15 +147,16 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
       setMobileDrawerOpen((open) => !open);
       return;
     }
-    // When expanding from a view that has no panel (e.g. welcome),
-    // restore the last panel view so the panel actually appears.
-    if (isCollapsed && !viewHasPanel(activeView)) {
+    // When the current view has no panel (e.g. welcome), the toggle should
+    // always restore the last panel view and ensure it's expanded — regardless
+    // of the current isCollapsed state — so the panel becomes visible.
+    if (!viewHasPanel(activeView)) {
       setActiveViewState(lastPanelViewRef.current);
       setIsCollapsed(false);
       return;
     }
     setIsCollapsed((prev) => !prev);
-  }, [isMobileNav, isCollapsed, activeView, setActiveViewState, setIsCollapsed, setMobileDrawerOpen]);
+  }, [isMobileNav, activeView, setActiveViewState, setIsCollapsed, setMobileDrawerOpen]);
 
   const toggleSidebar = useCallback(() => {
     if (isMobileNav) {
@@ -163,8 +164,8 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
       setMobileDrawerOpen((open) => !open);
       return;
     }
-    if (activeView === "welcome") {
-      // On the welcome page, ⌘B restores last panel view and expands
+    if (!viewHasPanel(activeView)) {
+      // On a non-panel view (e.g. welcome), ⌘B restores last panel view and expands
       setActiveViewState(lastPanelViewRef.current);
       setIsCollapsed(false);
     } else {


### PR DESCRIPTION
## Summary

- **Bug:** The previous fix (v0.18.6) only handled the case where `isCollapsed=true`. The real issue: when the panel was closed by clicking the active icon (switching `activeView` to `welcome` with `isCollapsed=false`), the toggle button would silently set `isCollapsed=true` on first click (no visible change), requiring a **second** click to expand.
- **Fix:** `toggleCollapse` now checks `!viewHasPanel(activeView)` regardless of `isCollapsed` state — always restores the last panel view and expands in one click.
- **Bonus:** Toggle button icon and label now use `panelOpen` instead of `isCollapsed` so they correctly reflect actual panel visibility.

### Files changed
- `src/contexts/sidebar-context.tsx` — `toggleCollapse` and `toggleSidebar` logic
- `src/components/layout/sidebar-icon-rail.tsx` — button icon/label driven by `panelOpen`